### PR TITLE
Switch to rem units for responsive design

### DIFF
--- a/app/root3/root3.tsx
+++ b/app/root3/root3.tsx
@@ -7,7 +7,7 @@ const Root3: NextPage = () => {
     <div className="w-full relative bg-[#f9fafc] overflow-hidden flex flex-col items-center justify-start !pt-[4.375rem] !pb-[4.375rem] !pl-[1.25rem] !pr-[1.25rem] box-border gap-[1.875rem] leading-[normal] tracking-[normal] text-center text-[1rem] text-[#5c67f7] font-[Poppins]">
       <div className="w-[41.688rem] flex flex-col items-center justify-start gap-[1.25rem]">
         <div className="flex flex-col items-center justify-center">
-          <div className="self-stretch relative border-[#5c67f7] border-solid border-t-[2px] box-border h-[0.125rem]" />
+          <div className="self-stretch relative border-[#5c67f7] border-solid border-t-[0.125rem] box-border h-[0.125rem]" />
           <div className="relative font-semibold">SSS’ler</div>
         </div>
         <div className="self-stretch flex flex-col items-center justify-start gap-[0.625rem] text-[1.5rem] text-[#27313c]">

--- a/components/bilgiler.tsx
+++ b/components/bilgiler.tsx
@@ -8,13 +8,13 @@ export type BilgilerType = {
 const Bilgiler: NextPage<BilgilerType> = ({ className = "" }) => {
   return (
     <div
-      className={`h-[421.5px] rounded-tl-[10px] rounded-tr-none rounded-br-none rounded-bl-[10px] bg-[#5c67f7] max-w-full flex flex-col items-center justify-start !pt-5 !pb-5 !pl-10 !pr-10 box-border gap-5 leading-[normal] tracking-[normal] text-center text-2xl text-[#fff] font-[Poppins] ${className}`}
+      className={`h-[26.344rem] rounded-tl-[0.625rem] rounded-tr-none rounded-br-none rounded-bl-[0.625rem] bg-[#5c67f7] max-w-full flex flex-col items-center justify-start !pt-5 !pb-5 !pl-10 !pr-10 box-border gap-5 leading-[normal] tracking-[normal] text-center text-2xl text-[#fff] font-[Poppins] ${className}`}
     >
       <h3 className="!m-0 relative text-[length:inherit] font-medium font-[inherit]">
         İletişim Bilgilerimiz
       </h3>
-      <section className="w-[345px] flex flex-col items-start justify-start gap-[15px] text-right text-[13px] text-[#fff] font-[Poppins]">
-        <div className="flex flex-row items-center justify-start gap-[5px]">
+      <section className="w-[21.563rem] flex flex-col items-start justify-start gap-[0.938rem] text-right text-[0.813rem] text-[#fff] font-[Poppins]">
+        <div className="flex flex-row items-center justify-start gap-[0.313rem]">
           <Image
             className="w-6 relative max-h-full overflow-hidden shrink-0"
             loading="lazy"
@@ -29,7 +29,7 @@ const Bilgiler: NextPage<BilgilerType> = ({ className = "" }) => {
             <span> Kurumun Açık Adresi (şehir / semt dahil)</span>
           </div>
         </div>
-        <div className="flex flex-row items-center justify-start gap-[5px]">
+        <div className="flex flex-row items-center justify-start gap-[0.313rem]">
           <Image
             className="w-6 relative max-h-full overflow-hidden shrink-0"
             loading="lazy"
@@ -44,7 +44,7 @@ const Bilgiler: NextPage<BilgilerType> = ({ className = "" }) => {
             <span> +90 5xx xxx xx xx</span>
           </div>
         </div>
-        <div className="flex flex-row items-center justify-start gap-[5px]">
+        <div className="flex flex-row items-center justify-start gap-[0.313rem]">
           <Image
             className="w-6 relative max-h-full overflow-hidden shrink-0"
             loading="lazy"
@@ -59,7 +59,7 @@ const Bilgiler: NextPage<BilgilerType> = ({ className = "" }) => {
             <span> info@kurumadi.com</span>
           </div>
         </div>
-        <div className="self-stretch flex flex-row items-center justify-start gap-[5px]">
+        <div className="self-stretch flex flex-row items-center justify-start gap-[0.313rem]">
           <Image
             className="w-6 relative max-h-full overflow-hidden shrink-0"
             loading="lazy"

--- a/components/component1.tsx
+++ b/components/component1.tsx
@@ -31,8 +31,8 @@ const Component1: NextPage<Component1Type> = ({ className = "" }) => {
           src="/ellipse-5.svg"
         />
       </div>
-      <div className="absolute top-[-6.875rem] left-[87rem] [filter:blur(17.6px)] rounded-[50%] [background:linear-gradient(90deg,_rgba(158,_92,_247,_0.4),_rgba(14,_165,_232,_0.4))] border-[rgba(158,92,247,0.5)] border-solid border-[0px] box-border w-[27.75rem] h-[27.75rem] z-[1]" />
-      <div className="absolute top-[14.313rem] left-[79.625rem] [filter:blur(33.4px)] rounded-[50%] bg-[rgba(255,255,255,0.08)] border-[#9e5cf7] border-solid border-[0px] box-border w-[34.125rem] h-[34.125rem] z-[2]" />
+      <div className="absolute top-[-6.875rem] left-[87rem] [filter:blur(17.6px)] rounded-[50%] [background:linear-gradient(90deg,_rgba(158,_92,_247,_0.4),_rgba(14,_165,_232,_0.4))] border-[rgba(158,92,247,0.5)] border-solid border-[0rem] box-border w-[27.75rem] h-[27.75rem] z-[1]" />
+      <div className="absolute top-[14.313rem] left-[79.625rem] [filter:blur(33.4px)] rounded-[50%] bg-[rgba(255,255,255,0.08)] border-[#9e5cf7] border-solid border-[0rem] box-border w-[34.125rem] h-[34.125rem] z-[2]" />
       <div className="absolute top-[43.294rem] left-[73.388rem] w-[58.813rem] h-[24.894rem] z-[3] overflow-hidden flex items-center justify-center">
         <Image
           className="w-full h-full z-[3] object-cover absolute left-[-0.187rem] top-[-0.187rem] [transform:scale(1.142)]"
@@ -57,11 +57,11 @@ const Component1: NextPage<Component1Type> = ({ className = "" }) => {
               src="/adasd.svg"
             />
             <div className="w-[31.5rem] h-[12.125rem] flex flex-row items-start justify-start !pt-[0rem] !pb-[0rem] !pl-[9.687rem] !pr-[9.687rem] box-border max-w-full">
-              <div className="self-stretch flex-1 relative [filter:blur(19.9px)] rounded-[50%] bg-[rgba(92,103,247,0.44)] border-[rgba(92,103,247,0.7)] border-solid border-[0px]" />
+              <div className="self-stretch flex-1 relative [filter:blur(19.9px)] rounded-[50%] bg-[rgba(92,103,247,0.44)] border-[rgba(92,103,247,0.7)] border-solid border-[0rem]" />
             </div>
           </div>
         </div>
-        <div className="h-[18.25rem] relative [filter:blur(19.9px)] rounded-[50%] bg-[rgba(92,103,247,0.74)] border-[#5c67f7] border-solid border-[0px] box-border min-w-[18.25rem] shrink-0 mq450:flex-1" />
+        <div className="h-[18.25rem] relative [filter:blur(19.9px)] rounded-[50%] bg-[rgba(92,103,247,0.74)] border-[#5c67f7] border-solid border-[0rem] box-border min-w-[18.25rem] shrink-0 mq450:flex-1" />
       </main>
     </main>
   );

--- a/components/component11.tsx
+++ b/components/component11.tsx
@@ -27,7 +27,7 @@ const Component11: NextPage<Component11Type> = ({
 
   return (
     <div
-      className={`w-[173px] rounded-md bg-[rgba(158,92,247,0.15)] overflow-hidden shrink-0 flex flex-row items-center justify-center !p-2.5 box-border text-left text-[15px] text-[#9e5cf7] font-[Poppins] data-[property1='static']:bg-[#9e5cf7] data-[property1='static']:[&_.text]:text-[#fff] ${className}`}
+      className={`w-[10.813rem] rounded-md bg-[rgba(158,92,247,0.15)] overflow-hidden shrink-0 flex flex-row items-center justify-center !p-2.5 box-border text-left text-[0.938rem] text-[#9e5cf7] font-[Poppins] data-[property1='static']:bg-[#9e5cf7] data-[property1='static']:[&_.text]:text-[#fff] ${className}`}
       data-property1={property1}
       style={component1Style}
     >

--- a/components/container.tsx
+++ b/components/container.tsx
@@ -9,7 +9,7 @@ const Container: NextPage<ContainerType> = ({ className = "" }) => {
     <div
       className={`flex flex-col items-center justify-center leading-[normal] tracking-[normal] text-center text-base text-[#5c67f7] font-[Poppins] ${className}`}
     >
-      <div className="self-stretch h-0.5 relative border-[#5c67f7] border-solid border-t-[2px] box-border" />
+      <div className="self-stretch h-0.5 relative border-[#5c67f7] border-solid border-t-[0.125rem] box-border" />
       <div className="relative font-semibold">Bize Ulaşın</div>
     </div>
   );

--- a/components/content-container.tsx
+++ b/components/content-container.tsx
@@ -12,13 +12,13 @@ const ContentContainer: NextPage<ContentContainerType> = ({
 }) => {
   return (
     <main
-      className={`self-stretch flex flex-row items-center justify-center gap-[30px] z-[1] ${className}`}
+      className={`self-stretch flex flex-row items-center justify-center gap-[1.875rem] z-[1] ${className}`}
     >
-      <section className="h-[311px] flex-[0.9113] shadow-[0px_4px_4px_rgba(0,_0,_0,_0.25)] rounded-[10px] bg-[#fff] overflow-hidden flex flex-row items-start justify-start !pt-[44.5px] !pb-[44.5px] !pl-16 !pr-16 box-border min-w-[419px] text-left text-2xl text-[#000] font-[Poppins] mq450:flex-1">
-        <div className="flex flex-col items-center justify-start gap-[30px]">
+      <section className="h-[19.438rem] flex-[0.9113] shadow-[0px_4px_4px_rgba(0,_0,_0,_0.25)] rounded-[0.625rem] bg-[#fff] overflow-hidden flex flex-row items-start justify-start !pt-[2.781rem] !pb-[2.781rem] !pl-16 !pr-16 box-border min-w-[26.188rem] text-left text-2xl text-[#000] font-[Poppins] mq450:flex-1">
+        <div className="flex flex-col items-center justify-start gap-[1.875rem]">
           <div className="self-stretch flex flex-col items-center justify-start gap-5">
             <Image
-              className="w-[47px] h-[47px] relative rounded-[122.5px]"
+              className="w-[2.938rem] h-[2.938rem] relative rounded-[7.656rem]"
               loading="lazy"
               width={47}
               height={47}
@@ -26,11 +26,11 @@ const ContentContainer: NextPage<ContentContainerType> = ({
               alt=""
               src="/planlanan-devler.svg"
             />
-            <div className="flex flex-col items-center justify-start gap-[5px]">
-              <h3 className="!m-0 relative text-[length:inherit] font-semibold font-[inherit] mq450:text-[19px]">
+            <div className="flex flex-col items-center justify-start gap-[0.313rem]">
+              <h3 className="!m-0 relative text-[length:inherit] font-semibold font-[inherit] mq450:text-[1.188rem]">
                 Tüm Süreçler Tek Platformda
               </h3>
-              <div className="relative text-[15px] text-[#6e829f] text-center">
+              <div className="relative text-[0.938rem] text-[#6e829f] text-center">
                 <p className="!m-0">
                   Eğitim süreçlerinizi hızlandırarak zamandan ve maliyetten
                 </p>
@@ -39,7 +39,7 @@ const ContentContainer: NextPage<ContentContainerType> = ({
             </div>
           </div>
           <Button
-            className="!pt-[7.5px] !pb-[7.5px] !pl-[15px] !pr-[15px]"
+            className="!pt-[0.469rem] !pb-[0.469rem] !pl-[0.938rem] !pr-[0.938rem]"
             disableElevation
             color="primary"
             variant="outlined"

--- a/components/d-a-s-h-b-o-a-r-d-s.tsx
+++ b/components/d-a-s-h-b-o-a-r-d-s.tsx
@@ -7,30 +7,30 @@ export type DASHBOARDSType = {
 const DASHBOARDS: NextPage<DASHBOARDSType> = ({ className = "" }) => {
   return (
     <section
-      className={`w-[1712px] h-[308.2px] flex flex-row items-start justify-start !pt-[19px] !pb-[18.3px] !pl-[217px] !pr-[216.3px] box-border relative z-[2] text-center text-[19.3px] text-[#000] font-[Poppins] ${className}`}
+      className={`w-[107rem] h-[19.263rem] flex flex-row items-start justify-start !pt-[1.188rem] !pb-[1.144rem] !pl-[13.563rem] !pr-[13.519rem] box-border relative z-[2] text-center text-[1.206rem] text-[#000] font-[Poppins] ${className}`}
     >
-      <section className="h-[227.4px] w-full !!m-[0 important] absolute top-[40px] right-[0px] left-[0px] flex flex-row items-center justify-between gap-0 z-[0] text-center text-[14.2px] text-[#000] font-[Poppins]">
-        <div className="h-[227.4px] w-[430px] shadow-[0px_4px_4px_rgba(0,_0,_0,_0.25)] rounded-[2.2px] bg-[#fff] flex flex-col items-center justify-center !pt-[5.5px] !pb-[15.5px] !pl-[5.5px] !pr-[5.5px] box-border gap-[15.5px]">
-          <div className="self-stretch h-[169.3px] relative hidden" />
+      <section className="h-[14.213rem] w-full !!m-[0 important] absolute top-[2.5rem] right-[0rem] left-[0rem] flex flex-row items-center justify-between gap-0 z-[0] text-center text-[0.888rem] text-[#000] font-[Poppins]">
+        <div className="h-[14.213rem] w-[26.875rem] shadow-[0px_4px_4px_rgba(0,_0,_0,_0.25)] rounded-[0.138rem] bg-[#fff] flex flex-col items-center justify-center !pt-[0.344rem] !pb-[0.969rem] !pl-[0.344rem] !pr-[0.344rem] box-border gap-[0.969rem]">
+          <div className="self-stretch h-[10.581rem] relative hidden" />
           <div className="relative font-medium">Veli</div>
         </div>
-        <div className="w-[430px] shadow-[0px_4px_4px_rgba(0,_0,_0,_0.25)] rounded-[2.2px] bg-[#fff] flex flex-col items-center justify-center !pt-[5.5px] !pb-[15.5px] !pl-[5.5px] !pr-[5.5px] box-border gap-[15.5px]">
-          <div className="self-stretch h-[169.4px] relative hidden" />
+        <div className="w-[26.875rem] shadow-[0px_4px_4px_rgba(0,_0,_0,_0.25)] rounded-[0.138rem] bg-[#fff] flex flex-col items-center justify-center !pt-[0.344rem] !pb-[0.969rem] !pl-[0.344rem] !pr-[0.344rem] box-border gap-[0.969rem]">
+          <div className="self-stretch h-[10.588rem] relative hidden" />
           <div className="relative font-medium">Servis Şoförü</div>
         </div>
       </section>
-      <section className="h-[270.9px] w-[1278.7px] flex flex-row items-center justify-between gap-0 z-[1] text-center text-[16.9px] text-[#000] font-[Poppins]">
-        <div className="h-[270.9px] w-[512.5px] shadow-[0px_4px_4px_rgba(0,_0,_0,_0.25)] rounded-[2.6px] bg-[#fff] flex flex-col items-center justify-center !pt-[6.6px] !pb-[18.5px] !pl-[6.6px] !pr-[6.6px] box-border gap-[18.5px]">
-          <div className="self-stretch h-[201.9px] relative hidden" />
+      <section className="h-[16.931rem] w-[79.919rem] flex flex-row items-center justify-between gap-0 z-[1] text-center text-[1.056rem] text-[#000] font-[Poppins]">
+        <div className="h-[16.931rem] w-[32.031rem] shadow-[0px_4px_4px_rgba(0,_0,_0,_0.25)] rounded-[0.163rem] bg-[#fff] flex flex-col items-center justify-center !pt-[0.413rem] !pb-[1.156rem] !pl-[0.413rem] !pr-[0.413rem] box-border gap-[1.156rem]">
+          <div className="self-stretch h-[12.619rem] relative hidden" />
           <div className="relative font-medium">Öğrenci</div>
         </div>
-        <div className="h-[270.9px] w-[512.5px] shadow-[0px_4px_4px_rgba(0,_0,_0,_0.25)] rounded-[2.6px] bg-[#fff] flex flex-col items-center justify-center !pt-[6.6px] !pb-[18.5px] !pl-[6.6px] !pr-[6.6px] box-border gap-[18.5px]">
-          <div className="self-stretch h-[201.9px] relative hidden" />
+        <div className="h-[16.931rem] w-[32.031rem] shadow-[0px_4px_4px_rgba(0,_0,_0,_0.25)] rounded-[0.163rem] bg-[#fff] flex flex-col items-center justify-center !pt-[0.413rem] !pb-[1.156rem] !pl-[0.413rem] !pr-[0.413rem] box-border gap-[1.156rem]">
+          <div className="self-stretch h-[12.619rem] relative hidden" />
           <div className="relative font-medium">Rehberlik</div>
         </div>
       </section>
-      <div className="h-full w-[583.1px] !!m-[0 important] absolute top-[0px] bottom-[0px] left-[564px] shadow-[0px_4px_4px_rgba(0,_0,_0,_0.25)] rounded-[3px] bg-[#fff] flex flex-col items-center justify-center !pt-[7.5px] !pb-[21.1px] !pl-[7.5px] !pr-[7.5px] box-border gap-[21.1px] z-[2]">
-        <div className="self-stretch h-[229.7px] relative hidden" />
+      <div className="h-full w-[36.444rem] !!m-[0 important] absolute top-[0rem] bottom-[0rem] left-[35.25rem] shadow-[0px_4px_4px_rgba(0,_0,_0,_0.25)] rounded-[0.188rem] bg-[#fff] flex flex-col items-center justify-center !pt-[0.469rem] !pb-[1.319rem] !pl-[0.469rem] !pr-[0.469rem] box-border gap-[1.319rem] z-[2]">
+        <div className="self-stretch h-[14.356rem] relative hidden" />
         <div className="relative font-medium">Öğretmen</div>
       </div>
     </section>

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -8,11 +8,11 @@ export type FooterType = {
 const Footer: NextPage<FooterType> = ({ className = "" }) => {
   return (
     <div
-      className={`w-full max-w-[1920px] mx-auto h-[551px] bg-[#192038] overflow-hidden flex flex-col items-start justify-start !pt-[74px] !pb-[25px] !pl-[157px] !pr-[157px] box-border gap-[184px] text-left text-base font-[Poppins] ${className}`}
+      className={`w-full max-w-[120rem] mx-auto h-[34.438rem] bg-[#192038] overflow-hidden flex flex-col items-start justify-start !pt-[4.625rem] !pb-[1.563rem] !pl-[9.813rem] !pr-[9.813rem] box-border gap-[11.5rem] text-left text-base font-[Poppins] ${className}`}
     >
-      <section className="w-[1306px] h-[244px] flex flex-row items-start justify-start gap-[107px] text-left text-xl text-[#fff] font-[Poppins]">
-        <div className="w-[459px] flex flex-col items-start justify-start gap-[21px] text-base text-[#a3a6af]">
-          <div className="flex flex-row items-center justify-start gap-[5px]">
+      <section className="w-[81.625rem] h-[15.25rem] flex flex-row items-start justify-start gap-[6.688rem] text-left text-xl text-[#fff] font-[Poppins]">
+        <div className="w-[28.688rem] flex flex-col items-start justify-start gap-[1.313rem] text-base text-[#a3a6af]">
+          <div className="flex flex-row items-center justify-start gap-[0.313rem]">
             <Image
               className="h-8 w-8 relative"
               loading="lazy"
@@ -23,7 +23,7 @@ const Footer: NextPage<FooterType> = ({ className = "" }) => {
               src="/headerebtexmavilogo.svg"
             />
             <Image
-              className="h-5 w-[90px] relative"
+              className="h-5 w-[5.625rem] relative"
               loading="lazy"
               width={90}
               height={20}
@@ -32,7 +32,7 @@ const Footer: NextPage<FooterType> = ({ className = "" }) => {
               src="/ebtexbeyaztext1.svg"
             />
           </div>
-          <div className="self-stretch relative tracking-[-0.01px] font-medium">
+          <div className="self-stretch relative tracking-[-0.001rem] font-medium">
             EBTEX, eğitim süreçlerinizi dijitalleştirerek size pratik ve başarı
             odaklı çözümler sunar. Modern teknolojilerle eğitimi
             kolaylaştırıyor, geleceğe hazır hale gelmenize yardımcı oluyoruz.
@@ -40,12 +40,12 @@ const Footer: NextPage<FooterType> = ({ className = "" }) => {
             bizimle iletişime geçin.
           </div>
         </div>
-        <div className="h-[244px] w-[445px] flex flex-row items-start justify-start !pt-0 !pb-0 !pl-0 !pr-9 box-border gap-[125px]">
-          <div className="flex flex-col items-start justify-start gap-[15px]">
+        <div className="h-[15.25rem] w-[27.813rem] flex flex-row items-start justify-start !pt-0 !pb-0 !pl-0 !pr-9 box-border gap-[7.813rem]">
+          <div className="flex flex-col items-start justify-start gap-[0.938rem]">
             <h3 className="!m-0 relative text-[length:inherit] font-medium font-[inherit]">
               Sayfalar
             </h3>
-            <div className="flex flex-col items-start justify-start gap-[11px] text-base text-[#a3a6af]">
+            <div className="flex flex-col items-start justify-start gap-[0.688rem] text-base text-[#a3a6af]">
               <div className="relative font-medium">Anasayfa</div>
               <div className="relative font-medium">Çözümler</div>
               <div className="relative font-medium">Ücretlendirme</div>
@@ -54,11 +54,11 @@ const Footer: NextPage<FooterType> = ({ className = "" }) => {
               <div className="relative font-medium">Bize Ulaşın</div>
             </div>
           </div>
-          <div className="flex flex-col items-start justify-start gap-[15px]">
+          <div className="flex flex-col items-start justify-start gap-[0.938rem]">
             <h3 className="!m-0 relative text-[length:inherit] font-medium font-[inherit]">
               Bilgi
             </h3>
-            <div className="flex flex-col items-start justify-start gap-[11px] text-base text-[#a3a6af]">
+            <div className="flex flex-col items-start justify-start gap-[0.688rem] text-base text-[#a3a6af]">
               <div className="relative font-medium">Neden EBTEX</div>
               <div className="relative font-medium">Hakkımızda</div>
               <div className="relative font-medium">EBTEX’i Keşfedin</div>
@@ -67,12 +67,12 @@ const Footer: NextPage<FooterType> = ({ className = "" }) => {
             </div>
           </div>
         </div>
-        <div className="flex flex-col items-start justify-start gap-[15px]">
+        <div className="flex flex-col items-start justify-start gap-[0.938rem]">
           <h3 className="!m-0 relative text-[length:inherit] font-medium font-[inherit]">
             İletişim
           </h3>
-          <div className="flex flex-col items-start justify-start gap-[30px] text-base text-[#a3a6af]">
-            <div className="flex flex-col items-start justify-start gap-[11px]">
+          <div className="flex flex-col items-start justify-start gap-[1.875rem] text-base text-[#a3a6af]">
+            <div className="flex flex-col items-start justify-start gap-[0.688rem]">
               <div className="flex flex-row items-center justify-center gap-2.5">
                 <Image
                   className="w-6 relative max-h-full overflow-hidden shrink-0"
@@ -110,11 +110,11 @@ const Footer: NextPage<FooterType> = ({ className = "" }) => {
                 <div className="relative font-medium">0 (552) 000 07 19</div>
               </div>
             </div>
-            <div className="flex flex-col items-start justify-start gap-[11px] text-[#fff]">
+            <div className="flex flex-col items-start justify-start gap-[0.688rem] text-[#fff]">
               <div className="relative font-medium">Bizi Takip Edin</div>
-              <div className="flex flex-row items-center justify-start gap-[5px]">
+              <div className="flex flex-row items-center justify-start gap-[0.313rem]">
                 <Image
-                  className="h-[35px] w-[35px] relative rounded-[5px] overflow-hidden shrink-0"
+                  className="h-[2.188rem] w-[2.188rem] relative rounded-[0.313rem] overflow-hidden shrink-0"
                   loading="lazy"
                   width={35}
                   height={35}
@@ -123,7 +123,7 @@ const Footer: NextPage<FooterType> = ({ className = "" }) => {
                   src="/utilitiescolorsbackgroundcolors.svg"
                 />
                 <Image
-                  className="h-[35px] w-[35px] relative rounded-[5px] overflow-hidden shrink-0 object-cover"
+                  className="h-[2.188rem] w-[2.188rem] relative rounded-[0.313rem] overflow-hidden shrink-0 object-cover"
                   loading="lazy"
                   width={35}
                   height={35}
@@ -132,7 +132,7 @@ const Footer: NextPage<FooterType> = ({ className = "" }) => {
                   src="/utilitiescolorsbackgroundcolors-1@2x.png"
                 />
                 <Image
-                  className="h-[35px] w-[35px] relative rounded-[5px] overflow-hidden shrink-0"
+                  className="h-[2.188rem] w-[2.188rem] relative rounded-[0.313rem] overflow-hidden shrink-0"
                   loading="lazy"
                   width={35}
                   height={35}
@@ -145,8 +145,8 @@ const Footer: NextPage<FooterType> = ({ className = "" }) => {
           </div>
         </div>
       </section>
-      <div className="w-[1172px] h-6 flex flex-row items-start justify-start !pt-0 !pb-0 !pl-[435px] !pr-0 box-border">
-        <div className="w-[737px] relative font-medium inline-block">
+      <div className="w-[73.25rem] h-6 flex flex-row items-start justify-start !pt-0 !pb-0 !pl-[27.188rem] !pr-0 box-border">
+        <div className="w-[46.063rem] relative font-medium inline-block">
           {`© 2025 `}
           <span className="[text-decoration:underline]">EBTEX</span>
           {` | `}

--- a/components/frame-component1.tsx
+++ b/components/frame-component1.tsx
@@ -7,20 +7,20 @@ export type FrameComponent1Type = {
 const FrameComponent1: NextPage<FrameComponent1Type> = ({ className = "" }) => {
   return (
     <div
-      className={`h-[386px] shadow-[0px_4px_4px_rgba(0,_0,_0,_0.25)] rounded-[30px] bg-[#fff] overflow-hidden flex flex-col items-start justify-start !pt-[27px] !pb-[27px] !pl-[29px] !pr-[29px] box-border gap-[25px] text-left text-[32px] text-[#27313c] font-[Poppins] ${className}`}
+      className={`h-[24.125rem] shadow-[0px_4px_4px_rgba(0,_0,_0,_0.25)] rounded-[1.875rem] bg-[#fff] overflow-hidden flex flex-col items-start justify-start !pt-[1.688rem] !pb-[1.688rem] !pl-[1.813rem] !pr-[1.813rem] box-border gap-[1.563rem] text-left text-[2rem] text-[#27313c] font-[Poppins] ${className}`}
     >
-      <div className="w-[183px] h-12 flex flex-row items-end justify-start !pt-0 !pb-px !pl-0 !pr-0 box-border text-right font-[Inter]">
-        <h2 className="!m-0 w-[140px] relative text-[length:inherit] inline-block shrink-0 z-[1] font-[inherit]">
+      <div className="w-[11.438rem] h-12 flex flex-row items-end justify-start !pt-0 !pb-px !pl-0 !pr-0 box-border text-right font-[Inter]">
+        <h2 className="!m-0 w-[8.75rem] relative text-[length:inherit] inline-block shrink-0 z-[1] font-[inherit]">
           <span>₺</span>
           <span className="font-[Poppins]">25.000</span>
         </h2>
-        <div className="h-[31px] w-[46px] flex flex-col items-start justify-end !pt-0 !pb-3 !pl-0 !pr-0 box-border z-[2] !ml-[-3px] relative text-base">
-          <div className="w-[46px] relative font-medium inline-block shrink-0">
+        <div className="h-[1.938rem] w-[2.875rem] flex flex-col items-start justify-end !pt-0 !pb-3 !pl-0 !pr-0 box-border z-[2] !ml-[-0.187rem] relative text-base">
+          <div className="w-[2.875rem] relative font-medium inline-block shrink-0">
             / Yıllık
           </div>
         </div>
       </div>
-      <div className="w-[495px] h-[210px] flex flex-col items-start justify-start text-[13px] text-[#6e829f]">
+      <div className="w-[30.938rem] h-[13.125rem] flex flex-col items-start justify-start text-[0.813rem] text-[#6e829f]">
         <div className="self-stretch relative font-medium">
           <p className="!m-0">
             Detaylı bilgi ve özel teklifler için bölge bayimizle veya sistem
@@ -30,8 +30,8 @@ const FrameComponent1: NextPage<FrameComponent1Type> = ({ className = "" }) => {
           <p className="!m-0">Telefon: 0555 123 45 67</p>
         </div>
       </div>
-      <div className="w-[495px] h-[38px] flex flex-col items-end justify-center text-[15px] text-[#fff]">
-        <div className="rounded-md bg-[#5c67f7] flex flex-row items-center justify-center !pt-[7.5px] !pb-[7.5px] !pl-[15px] !pr-[15px]">
+      <div className="w-[30.938rem] h-[2.375rem] flex flex-col items-end justify-center text-[0.938rem] text-[#fff]">
+        <div className="rounded-md bg-[#5c67f7] flex flex-row items-center justify-center !pt-[0.469rem] !pb-[0.469rem] !pl-[0.938rem] !pr-[0.938rem]">
           <div className="relative font-semibold">Satın Al</div>
         </div>
       </div>

--- a/components/frame-component11.tsx
+++ b/components/frame-component11.tsx
@@ -42,11 +42,11 @@ const FrameComponent2: NextPage<FrameComponent2Type> = ({
 
   return (
     <section
-      className={`w-[513px] rounded-[10px] border-[#6e78ed] border-solid border-[1px] box-border overflow-hidden shrink-0 flex flex-col items-center justify-center text-left text-xl text-[#fff] font-[Poppins] ${className}`}
+      className={`w-[32.063rem] rounded-[0.625rem] border-[#6e78ed] border-solid border-[0.063rem] box-border overflow-hidden shrink-0 flex flex-col items-center justify-center text-left text-xl text-[#fff] font-[Poppins] ${className}`}
     >
-      <div className="self-stretch h-[220px] bg-[#5e69ec] overflow-hidden shrink-0 flex flex-row items-start justify-start !pt-[45px] !pb-[45px] !pl-[25px] !pr-[25px] box-border">
+      <div className="self-stretch h-[13.75rem] bg-[#5e69ec] overflow-hidden shrink-0 flex flex-row items-start justify-start !pt-[2.813rem] !pb-[2.813rem] !pl-[1.563rem] !pr-[1.563rem] box-border">
         <div
-          className="h-[78px] w-[463px] flex flex-col items-start justify-start"
+          className="h-[4.875rem] w-[28.938rem] flex flex-col items-start justify-start"
           style={groupDivStyle}
         >
           <Image
@@ -59,7 +59,7 @@ const FrameComponent2: NextPage<FrameComponent2Type> = ({
             src="/bxsquoteleft.svg"
           />
           <div
-            className="w-[463px] relative inline-block shrink-0 z-[1] !mt-[-18px]"
+            className="w-[28.938rem] relative inline-block shrink-0 z-[1] !mt-[-1.125rem]"
             style={eBTEXIleHerContainerStyle}
           >
             <p className="!m-0 whitespace-pre-wrap">
@@ -70,14 +70,14 @@ const FrameComponent2: NextPage<FrameComponent2Type> = ({
           </div>
         </div>
       </div>
-      <div className="self-stretch h-[93px] bg-[#6e79ef] overflow-hidden shrink-0 flex flex-row items-center justify-start !pt-[30px] !pb-[30px] !pl-[25px] !pr-[25px] box-border gap-6">
-        <div className="w-[52px] relative rounded-[50%] bg-[#fff] h-[52px]" />
-        <div className="w-[228px] flex flex-col items-start justify-start">
+      <div className="self-stretch h-[5.813rem] bg-[#6e79ef] overflow-hidden shrink-0 flex flex-row items-center justify-start !pt-[1.875rem] !pb-[1.875rem] !pl-[1.563rem] !pr-[1.563rem] box-border gap-6">
+        <div className="w-[3.25rem] relative rounded-[50%] bg-[#fff] h-[3.25rem]" />
+        <div className="w-[14.25rem] flex flex-col items-start justify-start">
           <h3 className="!m-0 relative text-[length:inherit] font-semibold font-[inherit]">
             {mehmetKaya}
           </h3>
           <div
-            className="self-stretch relative text-[15px] font-medium text-[#e2e4fb]"
+            className="self-stretch relative text-[0.938rem] font-medium text-[#e2e4fb]"
             style={yneticiABCEitimStyle}
           >
             {yneticiABCEitimKurumlar}

--- a/components/frame-component2.tsx
+++ b/components/frame-component2.tsx
@@ -29,9 +29,9 @@ const FrameComponent21: NextPage<FrameComponent21Type> = ({
     <section
       className={`self-stretch flex-1 flex flex-row items-center justify-center gap-5 max-w-full text-center text-base text-[#27313c] font-[Poppins] ${className}`}
     >
-      <div className="h-[164px] w-[400px] shadow-[0px_4px_4px_rgba(0,_0,_0,_0.25)] rounded-[10px] bg-[#fff] border-[#e6eff3] border-solid border-[2px] box-border overflow-hidden shrink-0 flex flex-col items-center justify-center !p-2.5 gap-2.5 max-w-full">
+      <div className="h-[10.25rem] w-[25rem] shadow-[0px_4px_4px_rgba(0,_0,_0,_0.25)] rounded-[0.625rem] bg-[#fff] border-[#e6eff3] border-solid border-[0.125rem] box-border overflow-hidden shrink-0 flex flex-col items-center justify-center !p-2.5 gap-2.5 max-w-full">
         <Image
-          className="w-[72px] h-[72px] relative"
+          className="w-[4.5rem] h-[4.5rem] relative"
           loading="lazy"
           width={72}
           height={72}
@@ -41,9 +41,9 @@ const FrameComponent21: NextPage<FrameComponent21Type> = ({
         />
         <div className="relative font-semibold">{soruHavuzu}</div>
       </div>
-      <div className="h-[164px] w-[400px] shadow-[0px_4px_4px_rgba(0,_0,_0,_0.25)] rounded-[10px] bg-[#fff] border-[#e6eff3] border-solid border-[2px] box-border overflow-hidden shrink-0 flex flex-col items-center justify-center !p-2.5 gap-2.5 max-w-full">
+      <div className="h-[10.25rem] w-[25rem] shadow-[0px_4px_4px_rgba(0,_0,_0,_0.25)] rounded-[0.625rem] bg-[#fff] border-[#e6eff3] border-solid border-[0.125rem] box-border overflow-hidden shrink-0 flex flex-col items-center justify-center !p-2.5 gap-2.5 max-w-full">
         <Image
-          className="w-[72px] h-[72px] relative"
+          className="w-[4.5rem] h-[4.5rem] relative"
           loading="lazy"
           width={72}
           height={72}
@@ -53,9 +53,9 @@ const FrameComponent21: NextPage<FrameComponent21Type> = ({
         />
         <div className="relative font-semibold">{devTakip}</div>
       </div>
-      <div className="h-[164px] w-[400px] shadow-[0px_4px_4px_rgba(0,_0,_0,_0.25)] rounded-[10px] bg-[#fff] border-[#e6eff3] border-solid border-[2px] box-border overflow-hidden shrink-0 flex flex-col items-center justify-center !p-2.5 gap-2.5 max-w-full">
+      <div className="h-[10.25rem] w-[25rem] shadow-[0px_4px_4px_rgba(0,_0,_0,_0.25)] rounded-[0.625rem] bg-[#fff] border-[#e6eff3] border-solid border-[0.125rem] box-border overflow-hidden shrink-0 flex flex-col items-center justify-center !p-2.5 gap-2.5 max-w-full">
         <Image
-          className="w-[72px] h-[72px] relative"
+          className="w-[4.5rem] h-[4.5rem] relative"
           loading="lazy"
           width={72}
           height={72}
@@ -65,9 +65,9 @@ const FrameComponent21: NextPage<FrameComponent21Type> = ({
         />
         <div className="relative font-semibold">{yoklamaYnetim}</div>
       </div>
-      <div className="h-[164px] w-[400px] shadow-[0px_4px_4px_rgba(0,_0,_0,_0.25)] rounded-[10px] bg-[#fff] border-[#e6eff3] border-solid border-[2px] box-border overflow-hidden shrink-0 flex flex-col items-center justify-center !p-2.5 gap-2.5 max-w-full">
+      <div className="h-[10.25rem] w-[25rem] shadow-[0px_4px_4px_rgba(0,_0,_0,_0.25)] rounded-[0.625rem] bg-[#fff] border-[#e6eff3] border-solid border-[0.125rem] box-border overflow-hidden shrink-0 flex flex-col items-center justify-center !p-2.5 gap-2.5 max-w-full">
         <Image
-          className="w-[72px] h-[72px] relative"
+          className="w-[4.5rem] h-[4.5rem] relative"
           loading="lazy"
           width={72}
           height={72}

--- a/components/frame246.tsx
+++ b/components/frame246.tsx
@@ -9,13 +9,13 @@ export type Frame2461Type = {
 const Frame2461: NextPage<Frame2461Type> = ({ className = "" }) => {
   return (
     <div
-      className={`w-full max-w-[1920px] mx-auto h-[590px] bg-[#5561eb] overflow-hidden flex flex-col items-end justify-start !pt-[70px] !pb-[70.8px] !pl-[104px] !pr-[104px] box-border relative gap-[50px] text-center text-base text-[#fff] font-[Poppins] ${className}`}
+      className={`w-full max-w-[120rem] mx-auto h-[36.875rem] bg-[#5561eb] overflow-hidden flex flex-col items-end justify-start !pt-[4.375rem] !pb-[4.425rem] !pl-[6.5rem] !pr-[6.5rem] box-border relative gap-[3.125rem] text-center text-base text-[#fff] font-[Poppins] ${className}`}
     >
-      <main className="w-[1970px] h-[1266.3px] absolute !!m-[0 important] bottom-[-448px] left-[-40px] z-[0]">
-        <div className="absolute top-[368.3px] left-[1716px] w-[29.5px] flex flex-col items-start justify-start gap-[85px]">
-          <div className="self-stretch relative max-w-full h-[29.5px] shrink-0 overflow-hidden flex items-center justify-center">
+      <main className="w-[123.125rem] h-[79.144rem] absolute !!m-[0 important] bottom-[-28rem] left-[-2.5rem] z-[0]">
+        <div className="absolute top-[23.019rem] left-[107.25rem] w-[1.844rem] flex flex-col items-start justify-start gap-[5.313rem]">
+          <div className="self-stretch relative max-w-full h-[1.844rem] shrink-0 overflow-hidden flex items-center justify-center">
             <Image
-              className="self-stretch overflow-hidden h-full shrink-0 object-cover absolute left-[0px] top-[0px] w-full [transform:scale(1.736)]"
+              className="self-stretch overflow-hidden h-full shrink-0 object-cover absolute left-[0rem] top-[0rem] w-full [transform:scale(1.736)]"
               width={29.5}
               height={29.5}
               sizes="100vw"
@@ -23,9 +23,9 @@ const Frame2461: NextPage<Frame2461Type> = ({ className = "" }) => {
               src="/frame-244.svg"
             />
           </div>
-          <div className="self-stretch h-[29.5px] relative max-w-full shrink-0 overflow-hidden flex items-center justify-center">
+          <div className="self-stretch h-[1.844rem] relative max-w-full shrink-0 overflow-hidden flex items-center justify-center">
             <Image
-              className="self-stretch h-full overflow-hidden shrink-0 object-cover absolute left-[0px] top-[0px] w-full [transform:scale(1.736)]"
+              className="self-stretch h-full overflow-hidden shrink-0 object-cover absolute left-[0rem] top-[0rem] w-full [transform:scale(1.736)]"
               loading="lazy"
               width={29.5}
               height={29.5}
@@ -34,9 +34,9 @@ const Frame2461: NextPage<Frame2461Type> = ({ className = "" }) => {
               src="/frame-244.svg"
             />
           </div>
-          <div className="self-stretch h-[29.5px] relative max-w-full shrink-0 overflow-hidden flex items-center justify-center">
+          <div className="self-stretch h-[1.844rem] relative max-w-full shrink-0 overflow-hidden flex items-center justify-center">
             <Image
-              className="self-stretch h-full overflow-hidden shrink-0 object-cover absolute left-[0px] top-[0px] w-full [transform:scale(1.736)]"
+              className="self-stretch h-full overflow-hidden shrink-0 object-cover absolute left-[0rem] top-[0rem] w-full [transform:scale(1.736)]"
               loading="lazy"
               width={29.5}
               height={29.5}
@@ -45,9 +45,9 @@ const Frame2461: NextPage<Frame2461Type> = ({ className = "" }) => {
               src="/frame-244.svg"
             />
           </div>
-          <div className="self-stretch h-[29.5px] relative max-w-full shrink-0 overflow-hidden flex items-center justify-center">
+          <div className="self-stretch h-[1.844rem] relative max-w-full shrink-0 overflow-hidden flex items-center justify-center">
             <Image
-              className="self-stretch h-full overflow-hidden shrink-0 object-cover absolute left-[0px] top-[0px] w-full [transform:scale(1.736)]"
+              className="self-stretch h-full overflow-hidden shrink-0 object-cover absolute left-[0rem] top-[0rem] w-full [transform:scale(1.736)]"
               loading="lazy"
               width={29.5}
               height={29.5}
@@ -56,9 +56,9 @@ const Frame2461: NextPage<Frame2461Type> = ({ className = "" }) => {
               src="/frame-244.svg"
             />
           </div>
-          <div className="self-stretch relative max-w-full h-[29.5px] shrink-0 overflow-hidden flex items-center justify-center">
+          <div className="self-stretch relative max-w-full h-[1.844rem] shrink-0 overflow-hidden flex items-center justify-center">
             <Image
-              className="self-stretch overflow-hidden h-full shrink-0 object-cover absolute left-[0px] top-[-2px] w-full [transform:scale(1.736)]"
+              className="self-stretch overflow-hidden h-full shrink-0 object-cover absolute left-[0rem] top-[-0.125rem] w-full [transform:scale(1.736)]"
               width={29.5}
               height={29.5}
               sizes="100vw"
@@ -68,16 +68,16 @@ const Frame2461: NextPage<Frame2461Type> = ({ className = "" }) => {
           </div>
         </div>
         <Image
-          className="absolute top-[199.3px] left-[1737px] w-[233px] h-[234.8px]"
+          className="absolute top-[12.456rem] left-[108.563rem] w-[14.563rem] h-[14.675rem]"
           width={233}
           height={234.8}
           sizes="100vw"
           alt=""
           src="/vector-12.svg"
         />
-        <div className="absolute top-[0px] left-[1171.1px] w-[351.4px] h-[324.6px] overflow-hidden flex items-center justify-center">
+        <div className="absolute top-[0rem] left-[73.194rem] w-[21.963rem] h-[20.288rem] overflow-hidden flex items-center justify-center">
           <Image
-            className="w-full h-full object-cover absolute left-[3px] top-[117px] [transform:scale(1.015)]"
+            className="w-full h-full object-cover absolute left-[0.188rem] top-[7.313rem] [transform:scale(1.015)]"
             width={351.4}
             height={324.6}
             sizes="100vw"
@@ -85,9 +85,9 @@ const Frame2461: NextPage<Frame2461Type> = ({ className = "" }) => {
             src="/frame-62-1@2x.png"
           />
         </div>
-        <div className="absolute top-[865.3px] left-[294.8px] w-[534.7px] h-[401px] overflow-hidden flex items-center justify-center">
+        <div className="absolute top-[54.081rem] left-[18.425rem] w-[33.419rem] h-[25.063rem] overflow-hidden flex items-center justify-center">
           <Image
-            className="w-full h-full object-cover absolute left-[0px] top-[0px] [transform:scale(1.033)]"
+            className="w-full h-full object-cover absolute left-[0rem] top-[0rem] [transform:scale(1.033)]"
             width={534.7}
             height={401}
             sizes="100vw"
@@ -96,7 +96,7 @@ const Frame2461: NextPage<Frame2461Type> = ({ className = "" }) => {
           />
         </div>
         <Image
-          className="absolute top-[275.9px] left-[0px] w-[603px] h-[603px]"
+          className="absolute top-[17.244rem] left-[0rem] w-[37.688rem] h-[37.688rem]"
           width={603}
           height={603}
           sizes="100vw"
@@ -104,17 +104,17 @@ const Frame2461: NextPage<Frame2461Type> = ({ className = "" }) => {
           src="/vector-15.svg"
         />
         <Image
-          className="absolute top-[172.3px] left-[0px] w-[603px] h-[603px]"
+          className="absolute top-[10.769rem] left-[0rem] w-[37.688rem] h-[37.688rem]"
           width={603}
           height={603}
           sizes="100vw"
           alt=""
           src="/vector-16.svg"
         />
-        <div className="absolute top-[165.3px] left-[526.5px] rounded-[50%] [background:linear-gradient(-90deg,_#5a65ec,_#626cec)] w-[333.5px] h-[333.5px]" />
-        <div className="absolute top-[287.1px] left-[373px] w-[438.8px] h-[438.8px] overflow-hidden flex items-center justify-center">
+        <div className="absolute top-[10.331rem] left-[32.906rem] rounded-[50%] [background:linear-gradient(-90deg,_#5a65ec,_#626cec)] w-[20.844rem] h-[20.844rem]" />
+        <div className="absolute top-[17.944rem] left-[23.313rem] w-[27.425rem] h-[27.425rem] overflow-hidden flex items-center justify-center">
           <Image
-            className="w-full h-full object-cover absolute left-[0px] top-[0px] [transform:scale(1.023)]"
+            className="w-full h-full object-cover absolute left-[0rem] top-[0rem] [transform:scale(1.023)]"
             width={438.8}
             height={438.8}
             sizes="100vw"
@@ -123,21 +123,21 @@ const Frame2461: NextPage<Frame2461Type> = ({ className = "" }) => {
           />
         </div>
         <Image
-          className="absolute top-[224.3px] left-[30px] w-[257px] h-[257px]"
+          className="absolute top-[14.019rem] left-[1.875rem] w-[16.063rem] h-[16.063rem]"
           width={257}
           height={257}
           sizes="100vw"
           alt=""
           src="/vector-19.svg"
         />
-        <div className="absolute top-[228.3px] left-[40px] w-[1531px] h-[590px] flex flex-col items-end justify-start !pt-[681.2px] !pb-[206px] !pl-0 !pr-0 box-border gap-[297.2px]">
-          <section className="!mt-[-704.2px] w-[1531px] h-[407px] flex flex-row items-start justify-end !pt-0 !pb-0 !pl-0 !pr-[455px] box-border z-[2]">
-            <div className="h-[407px] w-[1102px] flex flex-row items-start justify-start gap-[48.5px] shrink-0">
-              <div className="h-[407px] w-[261px] flex flex-col items-start justify-start !pt-[82px] !pb-0 !pl-0 !pr-2 box-border z-[2]">
-                <div className="w-[253px] h-[325px] flex flex-col items-start justify-start gap-[12.5px]">
-                  <div className="w-[71.5px] relative h-[71.5px] z-[2] overflow-hidden flex items-center justify-center">
+        <div className="absolute top-[14.269rem] left-[2.5rem] w-[95.688rem] h-[36.875rem] flex flex-col items-end justify-start !pt-[42.575rem] !pb-[12.875rem] !pl-0 !pr-0 box-border gap-[18.575rem]">
+          <section className="!mt-[-44.012rem] w-[95.688rem] h-[25.438rem] flex flex-row items-start justify-end !pt-0 !pb-0 !pl-0 !pr-[28.438rem] box-border z-[2]">
+            <div className="h-[25.438rem] w-[68.875rem] flex flex-row items-start justify-start gap-[3.031rem] shrink-0">
+              <div className="h-[25.438rem] w-[16.313rem] flex flex-col items-start justify-start !pt-[5.125rem] !pb-0 !pl-0 !pr-2 box-border z-[2]">
+                <div className="w-[15.813rem] h-[20.313rem] flex flex-col items-start justify-start gap-[0.781rem]">
+                  <div className="w-[4.469rem] relative h-[4.469rem] z-[2] overflow-hidden flex items-center justify-center">
                     <Image
-                      className="w-full h-full z-[2] object-cover absolute left-[3px] top-[0px] [transform:scale(1.414)]"
+                      className="w-full h-full z-[2] object-cover absolute left-[0.188rem] top-[0rem] [transform:scale(1.414)]"
                       width={71.5}
                       height={71.5}
                       sizes="100vw"
@@ -145,10 +145,10 @@ const Frame2461: NextPage<Frame2461Type> = ({ className = "" }) => {
                       src="/vector-17.svg"
                     />
                   </div>
-                  <div className="w-[253px] h-[241px] flex flex-row items-start justify-start !pt-0 !pb-0 !pl-3 !pr-0 box-border z-[1]">
-                    <div className="h-[241px] w-full relative overflow-hidden flex items-center justify-center">
+                  <div className="w-[15.813rem] h-[15.063rem] flex flex-row items-start justify-start !pt-0 !pb-0 !pl-3 !pr-0 box-border z-[1]">
+                    <div className="h-[15.063rem] w-full relative overflow-hidden flex items-center justify-center">
                       <Image
-                        className="h-full w-full object-cover absolute left-[3px] top-[0px] [transform:scale(1.123)]"
+                        className="h-full w-full object-cover absolute left-[0.188rem] top-[0rem] [transform:scale(1.123)]"
                         width={241}
                         height={241}
                         sizes="100vw"
@@ -159,10 +159,10 @@ const Frame2461: NextPage<Frame2461Type> = ({ className = "" }) => {
                   </div>
                 </div>
               </div>
-              <div className="h-[400.5px] w-[432px] flex flex-col items-start justify-start !pt-[19px] !pb-0 !pl-0 !pr-0 box-border z-[1]">
-                <div className="w-full relative h-[381.5px] overflow-hidden flex items-center justify-center">
+              <div className="h-[25.031rem] w-[27rem] flex flex-col items-start justify-start !pt-[1.188rem] !pb-0 !pl-0 !pr-0 box-border z-[1]">
+                <div className="w-full relative h-[23.844rem] overflow-hidden flex items-center justify-center">
                   <Image
-                    className="w-full h-full object-cover absolute left-[0px] top-[0px] [transform:scale(1.04)]"
+                    className="w-full h-full object-cover absolute left-[0rem] top-[0rem] [transform:scale(1.04)]"
                     width={432}
                     height={381.5}
                     sizes="100vw"
@@ -171,9 +171,9 @@ const Frame2461: NextPage<Frame2461Type> = ({ className = "" }) => {
                   />
                 </div>
               </div>
-              <div className="w-[312px] relative h-[312px] overflow-hidden flex items-center justify-center">
+              <div className="w-[19.5rem] relative h-[19.5rem] overflow-hidden flex items-center justify-center">
                 <Image
-                  className="w-full h-full object-cover absolute left-[0px] top-[2px] [transform:scale(1.051)]"
+                  className="w-full h-full object-cover absolute left-[0rem] top-[0.125rem] [transform:scale(1.051)]"
                   width={312}
                   height={312}
                   sizes="100vw"
@@ -183,10 +183,10 @@ const Frame2461: NextPage<Frame2461Type> = ({ className = "" }) => {
               </div>
             </div>
           </section>
-          <div className="w-[1543px] h-[355.2px] flex flex-row items-start justify-start gap-[847.6px] shrink-0 z-[1]">
-            <div className="w-[355.2px] relative h-[355.2px] z-[2] overflow-hidden flex items-center justify-center">
+          <div className="w-[96.438rem] h-[22.2rem] flex flex-row items-start justify-start gap-[52.975rem] shrink-0 z-[1]">
+            <div className="w-[22.2rem] relative h-[22.2rem] z-[2] overflow-hidden flex items-center justify-center">
               <Image
-                className="w-full h-full z-[2] object-cover absolute left-[0px] top-[0px] [transform:scale(1.047)]"
+                className="w-full h-full z-[2] object-cover absolute left-[0rem] top-[0rem] [transform:scale(1.047)]"
                 width={355.2}
                 height={355.2}
                 sizes="100vw"
@@ -194,60 +194,60 @@ const Frame2461: NextPage<Frame2461Type> = ({ className = "" }) => {
                 src="/vector-13.svg"
               />
             </div>
-            <div className="h-[179.8px] w-[340.2px] flex flex-col items-start justify-start !pt-[39.8px] !pb-0 !pl-0 !pr-0 box-border z-[1]">
-              <div className="[filter:blur(5.2px)] flex flex-row items-center justify-start gap-[44.5px]">
-                <div className="w-[10.5px] flex flex-col items-start justify-start gap-[32.7px]">
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
+            <div className="h-[11.238rem] w-[21.263rem] flex flex-col items-start justify-start !pt-[2.488rem] !pb-0 !pl-0 !pr-0 box-border z-[1]">
+              <div className="[filter:blur(5.2px)] flex flex-row items-center justify-start gap-[2.781rem]">
+                <div className="w-[0.656rem] flex flex-col items-start justify-start gap-[2.044rem]">
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
                 </div>
-                <div className="w-[10.5px] flex flex-col items-start justify-start gap-[32.7px]">
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
+                <div className="w-[0.656rem] flex flex-col items-start justify-start gap-[2.044rem]">
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
                 </div>
-                <div className="w-[10.5px] flex flex-col items-start justify-start gap-[32.7px]">
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
+                <div className="w-[0.656rem] flex flex-col items-start justify-start gap-[2.044rem]">
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
                 </div>
-                <div className="w-[10.5px] flex flex-col items-start justify-start gap-[32.7px]">
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
+                <div className="w-[0.656rem] flex flex-col items-start justify-start gap-[2.044rem]">
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
                 </div>
-                <div className="w-[10.5px] flex flex-col items-start justify-start gap-[32.7px]">
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
+                <div className="w-[0.656rem] flex flex-col items-start justify-start gap-[2.044rem]">
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
                 </div>
-                <div className="w-[10.5px] flex flex-col items-start justify-start gap-[32.7px]">
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
+                <div className="w-[0.656rem] flex flex-col items-start justify-start gap-[2.044rem]">
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
                 </div>
-                <div className="w-[10.5px] flex flex-col items-start justify-start gap-[32.7px]">
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
+                <div className="w-[0.656rem] flex flex-col items-start justify-start gap-[2.044rem]">
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
                 </div>
               </div>
             </div>
           </div>
         </div>
       </main>
-      <div className="w-[1115px] h-[91px] flex flex-row items-start justify-end !pt-0 !pb-0 !pl-0 !pr-[595px] box-border z-[3]">
-        <div className="h-[91px] w-[520px] flex flex-col items-start justify-start gap-2.5">
-          <div className="w-[327.5px] h-6 flex flex-row items-start justify-start !pt-0 !pb-0 !pl-[190.5px] !pr-0 box-border z-[2]">
+      <div className="w-[69.688rem] h-[5.688rem] flex flex-row items-start justify-end !pt-0 !pb-0 !pl-0 !pr-[37.188rem] box-border z-[3]">
+        <div className="h-[5.688rem] w-[32.5rem] flex flex-col items-start justify-start gap-2.5">
+          <div className="w-[20.469rem] h-6 flex flex-row items-start justify-start !pt-0 !pb-0 !pl-[11.906rem] !pr-0 box-border z-[2]">
             <div className="flex flex-col items-center justify-center">
-              <div className="self-stretch relative border-[#fff] border-solid border-t-[2px] box-border h-0.5" />
+              <div className="self-stretch relative border-[#fff] border-solid border-t-[0.125rem] box-border h-0.5" />
               <div className="relative font-semibold">Kullanıcı Merkezi</div>
             </div>
           </div>
@@ -255,7 +255,7 @@ const Frame2461: NextPage<Frame2461Type> = ({ className = "" }) => {
             <h3 className="!m-0 relative text-[length:inherit] font-medium font-[inherit]">
               Eğitimde Her Rol İçin Özel Çözümler
             </h3>
-            <div className="w-[520px] relative text-sm font-medium text-[#dddffb] inline-block">
+            <div className="w-[32.5rem] relative text-sm font-medium text-[#dddffb] inline-block">
               EBTEX, her kullanıcı için kişiselleştirilmiş çözümlerle
               verimliliği artırır
             </div>

--- a/components/grme-navbar-on.tsx
+++ b/components/grme-navbar-on.tsx
@@ -8,10 +8,10 @@ export type GrmeNavbarOnType = {
 const GrmeNavbarOn: NextPage<GrmeNavbarOnType> = ({ className = "" }) => {
   return (
     <div
-      className={`w-full max-w-[1920px] mx-auto h-20 flex flex-row items-start justify-start ${className}`}
+      className={`w-full max-w-[120rem] mx-auto h-20 flex flex-row items-start justify-start ${className}`}
     >
-      <section className="h-20 w-full max-w-[1920px] flex flex-row items-start justify-start">
-        <div className="h-20 w-full max-w-[1920px] flex flex-row items-start justify-start">
+      <section className="h-20 w-full max-w-[120rem] flex flex-row items-start justify-start">
+        <div className="h-20 w-full max-w-[120rem] flex flex-row items-start justify-start">
           <Header />
         </div>
       </section>

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -9,9 +9,9 @@ export type HeaderType = {
 const Header: NextPage<HeaderType> = ({ className = "" }) => {
   return (
     <div
-      className={`h-20 w-full max-w-[1920px] mx-auto shadow-[0px_4px_4px_rgba(0,_0,_0,_0.25)] bg-[#fff] flex flex-row items-start justify-start !pt-[19px] !pb-[19px] !pl-[75px] !pr-[75px] box-border gap-[286px] text-left text-base text-[#27313c] font-[Poppins] ${className}`}
+      className={`h-20 w-full max-w-[120rem] mx-auto shadow-[0px_4px_4px_rgba(0,_0,_0,_0.25)] bg-[#fff] flex flex-row items-start justify-start !pt-[1.188rem] !pb-[1.188rem] !pl-[4.688rem] !pr-[4.688rem] box-border gap-[17.875rem] text-left text-base text-[#27313c] font-[Poppins] ${className}`}
     >
-      <div className="flex flex-row items-center justify-start gap-[5px]">
+      <div className="flex flex-row items-center justify-start gap-[0.313rem]">
         <Image
           className="h-8 w-8 relative"
           loading="lazy"
@@ -22,7 +22,7 @@ const Header: NextPage<HeaderType> = ({ className = "" }) => {
           src="/headerebtexmavilogo.svg"
         />
         <Image
-          className="h-5 w-[90px] relative"
+          className="h-5 w-[5.625rem] relative"
           loading="lazy"
           width={90}
           height={20}
@@ -31,7 +31,7 @@ const Header: NextPage<HeaderType> = ({ className = "" }) => {
           src="/ebtexbeyaztext.svg"
         />
       </div>
-      <div className="flex flex-row items-center justify-center gap-[15px]">
+      <div className="flex flex-row items-center justify-center gap-[0.938rem]">
         <div className="relative font-semibold">Anasayfa</div>
         <div className="relative font-semibold">Kurumsal</div>
         <div className="relative font-semibold">Çözümler</div>
@@ -40,7 +40,7 @@ const Header: NextPage<HeaderType> = ({ className = "" }) => {
         <div className="relative font-semibold">SSS</div>
         <div className="relative font-semibold">Bize Ulaşın</div>
       </div>
-      <div className="flex flex-row items-center justify-center gap-2.5 text-center text-[13px] text-[#9e5cf7]">
+      <div className="flex flex-row items-center justify-center gap-2.5 text-center text-[0.813rem] text-[#9e5cf7]">
         <SecondaryNavButton property1="default" tEXT="Giriş" />
         <SecondaryNavButton property1="default" tEXT="Demo" />
       </div>

--- a/components/kart1.tsx
+++ b/components/kart1.tsx
@@ -32,13 +32,13 @@ const Kart11: NextPage<Kart11Type> = ({
 
   return (
     <section
-      className={`h-[311px] flex-1 shadow-[0px_4px_4px_rgba(0,_0,_0,_0.25)] rounded-[10px] bg-[#fff] overflow-hidden flex flex-row items-start justify-start !pt-14 !pb-14 !pl-[43px] !pr-[43px] box-border min-w-[419px] text-left text-2xl text-[#000] font-[Poppins] ${className}`}
+      className={`h-[19.438rem] flex-1 shadow-[0px_4px_4px_rgba(0,_0,_0,_0.25)] rounded-[0.625rem] bg-[#fff] overflow-hidden flex flex-row items-start justify-start !pt-14 !pb-14 !pl-[2.688rem] !pr-[2.688rem] box-border min-w-[26.188rem] text-left text-2xl text-[#000] font-[Poppins] ${className}`}
       style={kart02Style}
     >
-      <div className="flex flex-col items-center justify-start gap-[30px]">
+      <div className="flex flex-col items-center justify-start gap-[1.875rem]">
         <div className="self-stretch flex flex-col items-center justify-start gap-5">
           <Image
-            className="w-[47px] h-[47px] relative rounded-[122.5px]"
+            className="w-[2.938rem] h-[2.938rem] relative rounded-[7.656rem]"
             loading="lazy"
             width={47}
             height={47}
@@ -46,17 +46,17 @@ const Kart11: NextPage<Kart11Type> = ({
             alt=""
             src={planlananDevler}
           />
-          <div className="flex flex-col items-center justify-start gap-[5px]">
-            <h3 className="!m-0 relative text-[length:inherit] font-semibold font-[inherit] mq450:text-[19px]">
+          <div className="flex flex-col items-center justify-start gap-[0.313rem]">
+            <h3 className="!m-0 relative text-[length:inherit] font-semibold font-[inherit] mq450:text-[1.188rem]">
               {akllAnalizLlebilirBaar}
             </h3>
-            <div className="relative text-[15px] text-[#6e829f] text-center">
+            <div className="relative text-[0.938rem] text-[#6e829f] text-center">
               {herRencininBireyselIhtiyalar}
             </div>
           </div>
         </div>
         <Button
-          className="!pt-[7.5px] !pb-[7.5px] !pl-[15px] !pr-[15px]"
+          className="!pt-[0.469rem] !pb-[0.469rem] !pl-[0.938rem] !pr-[0.938rem]"
           disableElevation
           color="primary"
           variant="contained"

--- a/components/mesaj-gnder.tsx
+++ b/components/mesaj-gnder.tsx
@@ -9,27 +9,27 @@ export type MesajGnderType = {
 const MesajGnder: NextPage<MesajGnderType> = ({ className = "" }) => {
   return (
     <div
-      className={`w-[964px] shadow-[0px_4px_4px_3px_rgba(0,_0,_0,_0.25)] rounded-[10px] bg-[#fff] border-[#e6eff3] border-solid border-[1px] box-border max-w-full overflow-hidden flex flex-row items-center justify-center !pt-[18px] !pb-[18px] !pl-[39px] !pr-[39px] gap-5 leading-[normal] tracking-[normal] text-center text-2xl text-[#27313c] font-[Poppins] ${className}`}
+      className={`w-[60.25rem] shadow-[0px_4px_4px_3px_rgba(0,_0,_0,_0.25)] rounded-[0.625rem] bg-[#fff] border-[#e6eff3] border-solid border-[0.063rem] box-border max-w-full overflow-hidden flex flex-row items-center justify-center !pt-[1.125rem] !pb-[1.125rem] !pl-[2.438rem] !pr-[2.438rem] gap-5 leading-[normal] tracking-[normal] text-center text-2xl text-[#27313c] font-[Poppins] ${className}`}
     >
       <Bilgiler />
       <div className="flex flex-col items-center justify-center flex-1 gap-5">
-        <h3 className="!m-0 relative text-[length:inherit] font-medium font-[inherit] mq450:text-[19px]">
+        <h3 className="!m-0 relative text-[length:inherit] font-medium font-[inherit] mq450:text-[1.188rem]">
           Mesaj Gönderin
         </h3>
-        <section className="self-stretch flex flex-col items-start justify-start gap-2.5 text-left text-[15px] text-[#27313c] font-[Poppins]">
+        <section className="self-stretch flex flex-col items-start justify-start gap-2.5 text-left text-[0.938rem] text-[#27313c] font-[Poppins]">
           <S adSoyad="Ad Soyad" adSoyadnzGiriniz="Ad soyadınızı Giriniz" />
           <S adSoyad="E-Posta" adSoyadnzGiriniz="E-Postanızı Giriniz" />
           <S adSoyad="Telefon" adSoyadnzGiriniz="Telefon Numaranızı Giriniz" />
           <S adSoyad="Kurum Adı" adSoyadnzGiriniz="Kurum Adını Giriniz" />
-          <div className="self-stretch flex flex-col items-start justify-center gap-[3px]">
+          <div className="self-stretch flex flex-col items-start justify-center gap-[0.188rem]">
             <div className="self-stretch relative font-medium">Mesaj</div>
-            <div className="self-stretch h-20 rounded-[10px] bg-[#f8f9f9] border-[#e6eff3] border-solid border-[1px] box-border flex flex-col items-start justify-start !p-2.5 text-right text-[13px] text-[#686f77]">
+            <div className="self-stretch h-20 rounded-[0.625rem] bg-[#f8f9f9] border-[#e6eff3] border-solid border-[0.063rem] box-border flex flex-col items-start justify-start !p-2.5 text-right text-[0.813rem] text-[#686f77]">
               <div className="relative">Mesajınızı Giriniz</div>
             </div>
           </div>
         </section>
-        <div className="self-stretch flex flex-col items-end justify-center text-left text-[15px] text-[#fff]">
-          <div className="rounded-md bg-[#5c67f7] flex flex-row items-center justify-center !pt-[7.5px] !pb-[7.5px] !pl-[15px] !pr-[15px]">
+        <div className="self-stretch flex flex-col items-end justify-center text-left text-[0.938rem] text-[#fff]">
+          <div className="rounded-md bg-[#5c67f7] flex flex-row items-center justify-center !pt-[0.469rem] !pb-[0.469rem] !pl-[0.938rem] !pr-[0.938rem]">
             <div className="relative font-semibold">Mesajı Gönder</div>
           </div>
         </div>

--- a/components/referanslarmz.tsx
+++ b/components/referanslarmz.tsx
@@ -9,13 +9,13 @@ export type ReferanslarmzType = {
 const Referanslarmz: NextPage<ReferanslarmzType> = ({ className = "" }) => {
   return (
     <div
-      className={`w-full max-w-[1920px] mx-auto h-[574px] bg-[#5561eb] overflow-hidden flex flex-col items-end justify-start !pt-[70px] !pb-[70px] !pl-[126.6px] !pr-[126.6px] box-border relative gap-[30px] text-center text-base text-[#fff] font-[Poppins] ${className}`}
+      className={`w-full max-w-[120rem] mx-auto h-[35.875rem] bg-[#5561eb] overflow-hidden flex flex-col items-end justify-start !pt-[4.375rem] !pb-[4.375rem] !pl-[7.913rem] !pr-[7.913rem] box-border relative gap-[1.875rem] text-center text-base text-[#fff] font-[Poppins] ${className}`}
     >
-      <main className="w-[1970px] h-[1266.3px] absolute !!m-[0 important] bottom-[-464px] left-[-40px] z-[0]">
-        <div className="absolute top-[368.3px] left-[1716px] w-[29.5px] flex flex-col items-start justify-start gap-[85px]">
-          <div className="self-stretch relative max-w-full h-[29.5px] shrink-0 overflow-hidden flex items-center justify-center">
+      <main className="w-[123.125rem] h-[79.144rem] absolute !!m-[0 important] bottom-[-29rem] left-[-2.5rem] z-[0]">
+        <div className="absolute top-[23.019rem] left-[107.25rem] w-[1.844rem] flex flex-col items-start justify-start gap-[5.313rem]">
+          <div className="self-stretch relative max-w-full h-[1.844rem] shrink-0 overflow-hidden flex items-center justify-center">
             <Image
-              className="self-stretch overflow-hidden h-full shrink-0 object-cover absolute left-[0px] top-[0px] w-full [transform:scale(1.736)]"
+              className="self-stretch overflow-hidden h-full shrink-0 object-cover absolute left-[0rem] top-[0rem] w-full [transform:scale(1.736)]"
               width={29.5}
               height={29.5}
               sizes="100vw"
@@ -23,9 +23,9 @@ const Referanslarmz: NextPage<ReferanslarmzType> = ({ className = "" }) => {
               src="/frame-244.svg"
             />
           </div>
-          <div className="self-stretch h-[29.5px] relative max-w-full shrink-0 overflow-hidden flex items-center justify-center">
+          <div className="self-stretch h-[1.844rem] relative max-w-full shrink-0 overflow-hidden flex items-center justify-center">
             <Image
-              className="self-stretch h-full overflow-hidden shrink-0 object-cover absolute left-[0px] top-[0px] w-full [transform:scale(1.736)]"
+              className="self-stretch h-full overflow-hidden shrink-0 object-cover absolute left-[0rem] top-[0rem] w-full [transform:scale(1.736)]"
               loading="lazy"
               width={29.5}
               height={29.5}
@@ -34,9 +34,9 @@ const Referanslarmz: NextPage<ReferanslarmzType> = ({ className = "" }) => {
               src="/frame-244.svg"
             />
           </div>
-          <div className="self-stretch h-[29.5px] relative max-w-full shrink-0 overflow-hidden flex items-center justify-center">
+          <div className="self-stretch h-[1.844rem] relative max-w-full shrink-0 overflow-hidden flex items-center justify-center">
             <Image
-              className="self-stretch h-full overflow-hidden shrink-0 object-cover absolute left-[0px] top-[0px] w-full [transform:scale(1.736)]"
+              className="self-stretch h-full overflow-hidden shrink-0 object-cover absolute left-[0rem] top-[0rem] w-full [transform:scale(1.736)]"
               loading="lazy"
               width={29.5}
               height={29.5}
@@ -45,9 +45,9 @@ const Referanslarmz: NextPage<ReferanslarmzType> = ({ className = "" }) => {
               src="/frame-244.svg"
             />
           </div>
-          <div className="self-stretch h-[29.5px] relative max-w-full shrink-0 overflow-hidden flex items-center justify-center">
+          <div className="self-stretch h-[1.844rem] relative max-w-full shrink-0 overflow-hidden flex items-center justify-center">
             <Image
-              className="self-stretch h-full overflow-hidden shrink-0 object-cover absolute left-[0px] top-[0px] w-full [transform:scale(1.736)]"
+              className="self-stretch h-full overflow-hidden shrink-0 object-cover absolute left-[0rem] top-[0rem] w-full [transform:scale(1.736)]"
               loading="lazy"
               width={29.5}
               height={29.5}
@@ -56,9 +56,9 @@ const Referanslarmz: NextPage<ReferanslarmzType> = ({ className = "" }) => {
               src="/frame-244.svg"
             />
           </div>
-          <div className="self-stretch relative max-w-full h-[29.5px] shrink-0 overflow-hidden flex items-center justify-center">
+          <div className="self-stretch relative max-w-full h-[1.844rem] shrink-0 overflow-hidden flex items-center justify-center">
             <Image
-              className="self-stretch overflow-hidden h-full shrink-0 object-cover absolute left-[0px] top-[0px] w-full [transform:scale(1.468)]"
+              className="self-stretch overflow-hidden h-full shrink-0 object-cover absolute left-[0rem] top-[0rem] w-full [transform:scale(1.468)]"
               width={29.5}
               height={29.5}
               sizes="100vw"
@@ -68,16 +68,16 @@ const Referanslarmz: NextPage<ReferanslarmzType> = ({ className = "" }) => {
           </div>
         </div>
         <Image
-          className="absolute top-[199.3px] left-[1737px] w-[233px] h-[234.8px]"
+          className="absolute top-[12.456rem] left-[108.563rem] w-[14.563rem] h-[14.675rem]"
           width={233}
           height={234.8}
           sizes="100vw"
           alt=""
           src="/vector-12.svg"
         />
-        <div className="absolute top-[0px] left-[1171.1px] w-[351.4px] h-[324.6px] overflow-hidden flex items-center justify-center">
+        <div className="absolute top-[0rem] left-[73.194rem] w-[21.963rem] h-[20.288rem] overflow-hidden flex items-center justify-center">
           <Image
-            className="w-full h-full object-cover absolute left-[3px] top-[117px] [transform:scale(1.015)]"
+            className="w-full h-full object-cover absolute left-[0.188rem] top-[7.313rem] [transform:scale(1.015)]"
             width={351.4}
             height={324.6}
             sizes="100vw"
@@ -85,9 +85,9 @@ const Referanslarmz: NextPage<ReferanslarmzType> = ({ className = "" }) => {
             src="/frame-62-11@2x.png"
           />
         </div>
-        <div className="absolute top-[865.3px] left-[294.8px] w-[534.7px] h-[401px] overflow-hidden flex items-center justify-center">
+        <div className="absolute top-[54.081rem] left-[18.425rem] w-[33.419rem] h-[25.063rem] overflow-hidden flex items-center justify-center">
           <Image
-            className="w-full h-full object-cover absolute left-[0px] top-[0px] [transform:scale(1.033)]"
+            className="w-full h-full object-cover absolute left-[0rem] top-[0rem] [transform:scale(1.033)]"
             width={534.7}
             height={401}
             sizes="100vw"
@@ -96,7 +96,7 @@ const Referanslarmz: NextPage<ReferanslarmzType> = ({ className = "" }) => {
           />
         </div>
         <Image
-          className="absolute top-[275.9px] left-[0px] w-[603px] h-[603px]"
+          className="absolute top-[17.244rem] left-[0rem] w-[37.688rem] h-[37.688rem]"
           width={603}
           height={603}
           sizes="100vw"
@@ -104,17 +104,17 @@ const Referanslarmz: NextPage<ReferanslarmzType> = ({ className = "" }) => {
           src="/vector-15.svg"
         />
         <Image
-          className="absolute top-[172.3px] left-[0px] w-[603px] h-[603px]"
+          className="absolute top-[10.769rem] left-[0rem] w-[37.688rem] h-[37.688rem]"
           width={603}
           height={603}
           sizes="100vw"
           alt=""
           src="/vector-16.svg"
         />
-        <div className="absolute top-[165.3px] left-[526.5px] rounded-[50%] [background:linear-gradient(-90deg,_#5a65ec,_#626cec)] w-[333.5px] h-[333.5px]" />
-        <div className="absolute top-[287.1px] left-[373px] w-[438.8px] h-[438.8px] overflow-hidden flex items-center justify-center">
+        <div className="absolute top-[10.331rem] left-[32.906rem] rounded-[50%] [background:linear-gradient(-90deg,_#5a65ec,_#626cec)] w-[20.844rem] h-[20.844rem]" />
+        <div className="absolute top-[17.944rem] left-[23.313rem] w-[27.425rem] h-[27.425rem] overflow-hidden flex items-center justify-center">
           <Image
-            className="w-full h-full object-cover absolute left-[0px] top-[0px] [transform:scale(1.023)]"
+            className="w-full h-full object-cover absolute left-[0rem] top-[0rem] [transform:scale(1.023)]"
             width={438.8}
             height={438.8}
             sizes="100vw"
@@ -123,21 +123,21 @@ const Referanslarmz: NextPage<ReferanslarmzType> = ({ className = "" }) => {
           />
         </div>
         <Image
-          className="absolute top-[224.3px] left-[30px] w-[257px] h-[257px]"
+          className="absolute top-[14.019rem] left-[1.875rem] w-[16.063rem] h-[16.063rem]"
           width={257}
           height={257}
           sizes="100vw"
           alt=""
           src="/vector-19.svg"
         />
-        <div className="absolute top-[228.3px] left-[40px] w-[1531px] h-[574px] flex flex-col items-end justify-start !pt-[681.2px] !pb-[190px] !pl-0 !pr-0 box-border gap-[297.2px]">
-          <section className="!mt-[-704.2px] w-[1531px] h-[407px] flex flex-row items-start justify-end !pt-0 !pb-0 !pl-0 !pr-[455px] box-border z-[2]">
-            <div className="h-[407px] w-[1102px] flex flex-row items-start justify-start gap-[48.5px] shrink-0">
-              <div className="h-[407px] w-[261px] flex flex-col items-start justify-start !pt-[82px] !pb-0 !pl-0 !pr-2 box-border z-[2]">
-                <div className="w-[253px] h-[325px] flex flex-col items-start justify-start gap-[12.5px]">
-                  <div className="w-[71.5px] relative h-[71.5px] z-[2] overflow-hidden flex items-center justify-center">
+        <div className="absolute top-[14.269rem] left-[2.5rem] w-[95.688rem] h-[35.875rem] flex flex-col items-end justify-start !pt-[42.575rem] !pb-[11.875rem] !pl-0 !pr-0 box-border gap-[18.575rem]">
+          <section className="!mt-[-44.012rem] w-[95.688rem] h-[25.438rem] flex flex-row items-start justify-end !pt-0 !pb-0 !pl-0 !pr-[28.438rem] box-border z-[2]">
+            <div className="h-[25.438rem] w-[68.875rem] flex flex-row items-start justify-start gap-[3.031rem] shrink-0">
+              <div className="h-[25.438rem] w-[16.313rem] flex flex-col items-start justify-start !pt-[5.125rem] !pb-0 !pl-0 !pr-2 box-border z-[2]">
+                <div className="w-[15.813rem] h-[20.313rem] flex flex-col items-start justify-start gap-[0.781rem]">
+                  <div className="w-[4.469rem] relative h-[4.469rem] z-[2] overflow-hidden flex items-center justify-center">
                     <Image
-                      className="w-full h-full z-[2] object-cover absolute left-[3px] top-[0px] [transform:scale(1.414)]"
+                      className="w-full h-full z-[2] object-cover absolute left-[0.188rem] top-[0rem] [transform:scale(1.414)]"
                       width={71.5}
                       height={71.5}
                       sizes="100vw"
@@ -145,10 +145,10 @@ const Referanslarmz: NextPage<ReferanslarmzType> = ({ className = "" }) => {
                       src="/vector-17.svg"
                     />
                   </div>
-                  <div className="w-[253px] h-[241px] flex flex-row items-start justify-start !pt-0 !pb-0 !pl-3 !pr-0 box-border z-[1]">
-                    <div className="h-[241px] w-full relative overflow-hidden flex items-center justify-center">
+                  <div className="w-[15.813rem] h-[15.063rem] flex flex-row items-start justify-start !pt-0 !pb-0 !pl-3 !pr-0 box-border z-[1]">
+                    <div className="h-[15.063rem] w-full relative overflow-hidden flex items-center justify-center">
                       <Image
-                        className="h-full w-full object-cover absolute left-[3px] top-[0px] [transform:scale(1.123)]"
+                        className="h-full w-full object-cover absolute left-[0.188rem] top-[0rem] [transform:scale(1.123)]"
                         width={241}
                         height={241}
                         sizes="100vw"
@@ -159,10 +159,10 @@ const Referanslarmz: NextPage<ReferanslarmzType> = ({ className = "" }) => {
                   </div>
                 </div>
               </div>
-              <div className="h-[400.5px] w-[432px] flex flex-col items-start justify-start !pt-[19px] !pb-0 !pl-0 !pr-0 box-border z-[1]">
-                <div className="w-full relative h-[381.5px] overflow-hidden flex items-center justify-center">
+              <div className="h-[25.031rem] w-[27rem] flex flex-col items-start justify-start !pt-[1.188rem] !pb-0 !pl-0 !pr-0 box-border z-[1]">
+                <div className="w-full relative h-[23.844rem] overflow-hidden flex items-center justify-center">
                   <Image
-                    className="w-full h-full object-cover absolute left-[0px] top-[0px] [transform:scale(1.04)]"
+                    className="w-full h-full object-cover absolute left-[0rem] top-[0rem] [transform:scale(1.04)]"
                     width={432}
                     height={381.5}
                     sizes="100vw"
@@ -171,9 +171,9 @@ const Referanslarmz: NextPage<ReferanslarmzType> = ({ className = "" }) => {
                   />
                 </div>
               </div>
-              <div className="w-[312px] relative h-[312px] overflow-hidden flex items-center justify-center">
+              <div className="w-[19.5rem] relative h-[19.5rem] overflow-hidden flex items-center justify-center">
                 <Image
-                  className="w-full h-full object-cover absolute left-[0px] top-[2px] [transform:scale(1.051)]"
+                  className="w-full h-full object-cover absolute left-[0rem] top-[0.125rem] [transform:scale(1.051)]"
                   width={312}
                   height={312}
                   sizes="100vw"
@@ -183,10 +183,10 @@ const Referanslarmz: NextPage<ReferanslarmzType> = ({ className = "" }) => {
               </div>
             </div>
           </section>
-          <div className="w-[1543px] h-[355.2px] flex flex-row items-start justify-start gap-[847.6px] shrink-0 z-[1]">
-            <div className="w-[355.2px] relative h-[355.2px] shrink-0 z-[2] overflow-hidden flex items-center justify-center">
+          <div className="w-[96.438rem] h-[22.2rem] flex flex-row items-start justify-start gap-[52.975rem] shrink-0 z-[1]">
+            <div className="w-[22.2rem] relative h-[22.2rem] shrink-0 z-[2] overflow-hidden flex items-center justify-center">
               <Image
-                className="w-full h-full shrink-0 z-[2] object-cover absolute left-[0px] top-[0px] [transform:scale(1.047)]"
+                className="w-full h-full shrink-0 z-[2] object-cover absolute left-[0rem] top-[0rem] [transform:scale(1.047)]"
                 width={355.2}
                 height={355.2}
                 sizes="100vw"
@@ -194,60 +194,60 @@ const Referanslarmz: NextPage<ReferanslarmzType> = ({ className = "" }) => {
                 src="/vector-13.svg"
               />
             </div>
-            <div className="h-[179.8px] w-[340.2px] flex flex-col items-start justify-start !pt-[39.8px] !pb-0 !pl-0 !pr-0 box-border z-[1]">
-              <div className="[filter:blur(5.2px)] flex flex-row items-center justify-start gap-[44.5px] shrink-0">
-                <div className="w-[10.5px] flex flex-col items-start justify-start gap-[32.7px]">
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
+            <div className="h-[11.238rem] w-[21.263rem] flex flex-col items-start justify-start !pt-[2.488rem] !pb-0 !pl-0 !pr-0 box-border z-[1]">
+              <div className="[filter:blur(5.2px)] flex flex-row items-center justify-start gap-[2.781rem] shrink-0">
+                <div className="w-[0.656rem] flex flex-col items-start justify-start gap-[2.044rem]">
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
                 </div>
-                <div className="w-[10.5px] flex flex-col items-start justify-start gap-[32.7px]">
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
+                <div className="w-[0.656rem] flex flex-col items-start justify-start gap-[2.044rem]">
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
                 </div>
-                <div className="w-[10.5px] flex flex-col items-start justify-start gap-[32.7px]">
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
+                <div className="w-[0.656rem] flex flex-col items-start justify-start gap-[2.044rem]">
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
                 </div>
-                <div className="w-[10.5px] flex flex-col items-start justify-start gap-[32.7px]">
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
+                <div className="w-[0.656rem] flex flex-col items-start justify-start gap-[2.044rem]">
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
                 </div>
-                <div className="w-[10.5px] flex flex-col items-start justify-start gap-[32.7px]">
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
+                <div className="w-[0.656rem] flex flex-col items-start justify-start gap-[2.044rem]">
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
                 </div>
-                <div className="w-[10.5px] flex flex-col items-start justify-start gap-[32.7px]">
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
+                <div className="w-[0.656rem] flex flex-col items-start justify-start gap-[2.044rem]">
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
                 </div>
-                <div className="w-[10.5px] flex flex-col items-start justify-start gap-[32.7px]">
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
-                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[10.5px]" />
+                <div className="w-[0.656rem] flex flex-col items-start justify-start gap-[2.044rem]">
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
+                  <div className="self-stretch relative rounded-[50%] bg-[#5d68f2] h-[0.656rem]" />
                 </div>
               </div>
             </div>
           </div>
         </div>
       </main>
-      <div className="w-[1083.4px] h-[91px] flex flex-row items-start justify-end !pt-0 !pb-0 !pl-0 !pr-[563.4px] box-border z-[1]">
-        <div className="h-[91px] w-[520px] flex flex-col items-start justify-start gap-2.5">
-          <div className="w-[314px] h-6 flex flex-row items-start justify-start !pt-0 !pb-0 !pl-[186px] !pr-0 box-border z-[2]">
+      <div className="w-[67.713rem] h-[5.688rem] flex flex-row items-start justify-end !pt-0 !pb-0 !pl-0 !pr-[35.213rem] box-border z-[1]">
+        <div className="h-[5.688rem] w-[32.5rem] flex flex-col items-start justify-start gap-2.5">
+          <div className="w-[19.625rem] h-6 flex flex-row items-start justify-start !pt-0 !pb-0 !pl-[11.625rem] !pr-0 box-border z-[2]">
             <div className="flex flex-col items-center justify-center">
-              <div className="self-stretch relative border-[#fff] border-solid border-t-[2px] box-border h-0.5" />
+              <div className="self-stretch relative border-[#fff] border-solid border-t-[0.125rem] box-border h-0.5" />
               <div className="relative font-semibold">Referanslarımız</div>
             </div>
           </div>
@@ -255,14 +255,14 @@ const Referanslarmz: NextPage<ReferanslarmzType> = ({ className = "" }) => {
             <h3 className="!m-0 relative text-[length:inherit] font-medium font-[inherit]">
               EBTEX ile Başaran Kurumların Deneyimleri
             </h3>
-            <div className="w-[520px] relative text-sm font-medium text-[#dddffb] inline-block">
+            <div className="w-[32.5rem] relative text-sm font-medium text-[#dddffb] inline-block">
               Eğitim kurumlarının başarı hikâyelerini kullanıcılarımızdan
               dinleyin!
             </div>
           </div>
         </div>
       </div>
-      <section className="flex flex-row items-center justify-start gap-[63.3px] z-[2]">
+      <section className="flex flex-row items-center justify-start gap-[3.956rem] z-[2]">
         <FrameComponent2
           mehmetKaya="Mehmet Kaya"
           yneticiABCEitimKurumlar="Yönetici, ABC Eğitim Kurumları"

--- a/components/root.tsx
+++ b/components/root.tsx
@@ -8,18 +8,18 @@ export type RootType = {
 const Root: NextPage<RootType> = ({ className = "" }) => {
   return (
     <div
-      className={`w-full max-w-[1920px] mx-auto bg-[#f9fafc] overflow-hidden flex flex-col items-start justify-start !pt-[70px] !pb-[85px] !pl-[91px] !pr-[91px] box-border gap-[50px] leading-[normal] tracking-[normal] ${className}`}
+      className={`w-full max-w-[120rem] mx-auto bg-[#f9fafc] overflow-hidden flex flex-col items-start justify-start !pt-[4.375rem] !pb-[5.313rem] !pl-[5.688rem] !pr-[5.688rem] box-border gap-[3.125rem] leading-[normal] tracking-[normal] ${className}`}
     >
-      <section className="flex flex-row items-start justify-start !pt-0 !pb-0 !pl-[533px] !pr-[533px] box-border max-w-full text-center text-base text-[#5c67f7] font-[Poppins] mq450:!pl-5 mq450:!pr-5 mq450:box-border">
+      <section className="flex flex-row items-start justify-start !pt-0 !pb-0 !pl-[33.313rem] !pr-[33.313rem] box-border max-w-full text-center text-base text-[#5c67f7] font-[Poppins] mq450:!pl-5 mq450:!pr-5 mq450:box-border">
         <div className="self-stretch flex flex-col items-end justify-start gap-2.5 max-w-full">
-          <div className="flex flex-row items-start justify-end !pt-0 !pb-0 !pl-[271px] !pr-[271px] box-border max-w-full mq450:!pl-5 mq450:!pr-5 mq450:box-border">
+          <div className="flex flex-row items-start justify-end !pt-0 !pb-0 !pl-[16.938rem] !pr-[16.938rem] box-border max-w-full mq450:!pl-5 mq450:!pr-5 mq450:box-border">
             <div className="h-6 flex flex-col items-center justify-center">
-              <div className="self-stretch relative border-[#5c67f7] border-solid border-t-[2px] box-border h-0.5" />
+              <div className="self-stretch relative border-[#5c67f7] border-solid border-t-[0.125rem] box-border h-0.5" />
               <div className="relative font-semibold">Neden Ebtex</div>
             </div>
           </div>
           <div className="self-stretch flex-1 flex flex-col items-center justify-start text-2xl text-[#27313c]">
-            <h3 className="!m-0 self-stretch flex-1 relative text-[length:inherit] font-medium font-[inherit] mq450:text-[19px]">
+            <h3 className="!m-0 self-stretch flex-1 relative text-[length:inherit] font-medium font-[inherit] mq450:text-[1.188rem]">
               EBTEX, Başarınızı Artırır ve Marka Değerinizi Güçlendirir!
             </h3>
             <div className="self-stretch relative text-sm font-medium text-[#6e829f]">

--- a/components/root1.tsx
+++ b/components/root1.tsx
@@ -8,36 +8,36 @@ export type Root1Type = {
 const Root1: NextPage<Root1Type> = ({ className = "" }) => {
   return (
     <div
-      className={`w-full max-w-[1920px] mx-auto h-[696px] bg-[#f9fafc] overflow-hidden flex flex-col items-center justify-start !pt-[70px] !pb-[70px] !pl-5 !pr-5 box-border gap-[50px] leading-[normal] tracking-[normal] text-center text-base text-[#5c67f7] font-[Poppins] ${className}`}
+      className={`w-full max-w-[120rem] mx-auto h-[43.5rem] bg-[#f9fafc] overflow-hidden flex flex-col items-center justify-start !pt-[4.375rem] !pb-[4.375rem] !pl-5 !pr-5 box-border gap-[3.125rem] leading-[normal] tracking-[normal] text-center text-base text-[#5c67f7] font-[Poppins] ${className}`}
     >
-      <div className="flex flex-row items-start justify-start !pt-0 !pb-0 !pl-[155px] !pr-[155px] box-border max-w-full">
+      <div className="flex flex-row items-start justify-start !pt-0 !pb-0 !pl-[9.688rem] !pr-[9.688rem] box-border max-w-full">
         <div className="self-stretch flex flex-col items-end justify-start gap-2.5 max-w-full">
-          <div className="flex flex-row items-start justify-end !pt-0 !pb-0 !pl-[268px] !pr-[267px] mq450:!pl-5 mq450:!pr-5 mq450:box-border">
+          <div className="flex flex-row items-start justify-end !pt-0 !pb-0 !pl-[16.75rem] !pr-[16.688rem] mq450:!pl-5 mq450:!pr-5 mq450:box-border">
             <div className="h-6 flex flex-col items-center justify-center">
-              <div className="self-stretch relative border-[#5c67f7] border-solid border-t-[2px] box-border h-0.5" />
+              <div className="self-stretch relative border-[#5c67f7] border-solid border-t-[0.125rem] box-border h-0.5" />
               <div className="relative font-semibold">EBTEX’i Keşfedin</div>
             </div>
           </div>
           <div className="flex-1 flex flex-col items-center justify-start text-2xl text-[#27313c]">
-            <h3 className="!m-0 flex-1 relative text-[length:inherit] font-medium font-[inherit] mq450:text-[19px]">
+            <h3 className="!m-0 flex-1 relative text-[length:inherit] font-medium font-[inherit] mq450:text-[1.188rem]">
               Eğitimde Dijital Çözümünüz: EBTEX
             </h3>
-            <div className="w-[667px] relative text-sm font-medium text-[#6e829f] inline-block">
+            <div className="w-[41.688rem] relative text-sm font-medium text-[#6e829f] inline-block">
               Tüm paydaşları bir araya getirerek eğitim süreçlerindeki başarıyı
               daha etkili bir şekilde izleyin
             </div>
           </div>
         </div>
       </div>
-      <section className="bg-[#7f92ff] overflow-hidden flex flex-row items-start justify-start !pt-[134px] !pb-0 !pl-0 !pr-0 box-border max-w-full text-center text-[25.1px] text-[#6e829f] font-[Inter] mq450:!pt-[87px] mq450:box-border">
-        <div className="flex-1 [background:linear-gradient(180deg,_rgba(127,_146,_255,_0),_#000)] flex flex-row items-start justify-start !pt-[163px] !pb-10 !pl-10 !pr-10 box-border max-w-full">
-          <div className="h-[281px] w-[978px] relative [background:linear-gradient(180deg,_rgba(127,_146,_255,_0),_#000)] hidden max-w-full" />
-          <div className="h-[78px] flex-1 flex flex-col items-start justify-start gap-[34px] max-w-full mq450:gap-[17px]">
+      <section className="bg-[#7f92ff] overflow-hidden flex flex-row items-start justify-start !pt-[8.375rem] !pb-0 !pl-0 !pr-0 box-border max-w-full text-center text-[1.569rem] text-[#6e829f] font-[Inter] mq450:!pt-[5.438rem] mq450:box-border">
+        <div className="flex-1 [background:linear-gradient(180deg,_rgba(127,_146,_255,_0),_#000)] flex flex-row items-start justify-start !pt-[10.188rem] !pb-10 !pl-10 !pr-10 box-border max-w-full">
+          <div className="h-[17.563rem] w-[61.125rem] relative [background:linear-gradient(180deg,_rgba(127,_146,_255,_0),_#000)] hidden max-w-full" />
+          <div className="h-[4.875rem] flex-1 flex flex-col items-start justify-start gap-[2.125rem] max-w-full mq450:gap-[1.063rem]">
             <div className="self-stretch flex flex-row items-center justify-between gap-0">
-              <div className="flex flex-row items-center justify-start gap-[7px]">
+              <div className="flex flex-row items-center justify-start gap-[0.438rem]">
                 <div className="h-11 w-11 relative overflow-hidden flex items-center justify-center">
                   <Image
-                    className="h-full w-full object-cover absolute left-[6px] top-[0px] [transform:scale(1)]"
+                    className="h-full w-full object-cover absolute left-[0.375rem] top-[0rem] [transform:scale(1)]"
                     loading="lazy"
                     width={44}
                     height={44}
@@ -48,7 +48,7 @@ const Root1: NextPage<Root1Type> = ({ className = "" }) => {
                 </div>
                 <b className="relative mq450:text-xl">0:00</b>
               </div>
-              <div className="flex flex-row items-center justify-start gap-[54px]">
+              <div className="flex flex-row items-center justify-start gap-[3.375rem]">
                 <Image
                   className="w-11 relative max-h-full overflow-hidden shrink-0"
                   loading="lazy"

--- a/components/root2.tsx
+++ b/components/root2.tsx
@@ -13,25 +13,25 @@ export type Root2Type = {
 const Root2: NextPage<Root2Type> = ({ className = "", property1 = 10 }) => {
   return (
     <div
-      className={`w-full max-w-[1920px] mx-auto h-[699px] bg-[#e9ecfb] overflow-hidden flex flex-col items-end justify-start !pt-[70px] !pb-[70px] !pl-[367px] !pr-[367px] box-border gap-10 text-center text-base text-[#5c67f7] font-[Poppins] ${className}`}
+      className={`w-full max-w-[120rem] mx-auto h-[43.688rem] bg-[#e9ecfb] overflow-hidden flex flex-col items-end justify-start !pt-[4.375rem] !pb-[4.375rem] !pl-[22.938rem] !pr-[22.938rem] box-border gap-10 text-center text-base text-[#5c67f7] font-[Poppins] ${className}`}
       data-property1={property1}
     >
-      <div className="w-[860px] h-[70px] flex flex-row items-start justify-end !pt-0 !pb-0 !pl-0 !pr-[324px] box-border">
-        <div className="h-[70px] w-[536px] flex flex-col items-start justify-start gap-2.5">
-          <div className="w-[326px] h-6 flex flex-row items-start justify-start !pt-0 !pb-0 !pl-[209px] !pr-0 box-border">
+      <div className="w-[53.75rem] h-[4.375rem] flex flex-row items-start justify-end !pt-0 !pb-0 !pl-0 !pr-[20.25rem] box-border">
+        <div className="h-[4.375rem] w-[33.5rem] flex flex-col items-start justify-start gap-2.5">
+          <div className="w-[20.375rem] h-6 flex flex-row items-start justify-start !pt-0 !pb-0 !pl-[13.063rem] !pr-0 box-border">
             <div className="flex flex-col items-center justify-center">
-              <div className="self-stretch relative border-[#5c67f7] border-solid border-t-[2px] box-border h-0.5" />
+              <div className="self-stretch relative border-[#5c67f7] border-solid border-t-[0.125rem] box-border h-0.5" />
               <div className="relative font-semibold">Ücretlendirme</div>
             </div>
           </div>
-          <h3 className="!m-0 w-[536px] relative text-2xl font-medium font-[inherit] text-[#27313c] inline-block">
+          <h3 className="!m-0 w-[33.5rem] relative text-2xl font-medium font-[inherit] text-[#27313c] inline-block">
             EBTEX İle Her Kuruma Uygun Esnek Çözümler
           </h3>
         </div>
       </div>
-      <main className="w-[1186px] h-[449px] flex flex-col items-start justify-start gap-5">
-        <div className="w-[807px] h-[43px] flex flex-row items-start justify-start !pt-0 !pb-0 !pl-[378px] !pr-0 box-border">
-          <div className="flex flex-row items-center justify-center gap-[83px]">
+      <main className="w-[74.125rem] h-[28.063rem] flex flex-col items-start justify-start gap-5">
+        <div className="w-[50.438rem] h-[2.688rem] flex flex-row items-start justify-start !pt-0 !pb-0 !pl-[23.625rem] !pr-0 box-border">
+          <div className="flex flex-row items-center justify-center gap-[5.188rem]">
             <Component11
               property1="static"
               component1AlignSelf="stretch"
@@ -40,15 +40,15 @@ const Root2: NextPage<Root2Type> = ({ className = "", property1 = 10 }) => {
             <Component11 property1="default" tEXT="Kurumsal (Kurs)" />
           </div>
         </div>
-        <section className="w-[1186px] h-[386px] flex flex-row items-start justify-start gap-20 text-right text-[32px] text-[#fff] font-[Poppins]">
-          <div className="shadow-[0px_4px_4px_rgba(0,_0,_0,_0.25)] rounded-[30px] bg-[#5c67f7] overflow-hidden flex flex-col items-start justify-start !pt-[27px] !pb-[27px] !pl-[29px] !pr-[29px] gap-[25px]">
+        <section className="w-[74.125rem] h-[24.125rem] flex flex-row items-start justify-start gap-20 text-right text-[2rem] text-[#fff] font-[Poppins]">
+          <div className="shadow-[0px_4px_4px_rgba(0,_0,_0,_0.25)] rounded-[1.875rem] bg-[#5c67f7] overflow-hidden flex flex-col items-start justify-start !pt-[1.688rem] !pb-[1.688rem] !pl-[1.813rem] !pr-[1.813rem] gap-[1.563rem]">
             <h1 className="!m-0 relative text-[length:inherit] font-semibold font-[inherit]">
               Ücret Hesapla
             </h1>
-            <div className="w-[495px] flex flex-col items-start justify-start gap-[25px] text-[13px]">
+            <div className="w-[30.938rem] flex flex-col items-start justify-start gap-[1.563rem] text-[0.813rem]">
               <div className="self-stretch flex flex-col items-start justify-start gap-3">
                 <div className="self-stretch flex flex-row items-center justify-between gap-0">
-                  <div className="w-[249px] flex flex-row items-center justify-start gap-[9px]">
+                  <div className="w-[15.563rem] flex flex-row items-center justify-start gap-[0.563rem]">
                     <Image
                       className="h-5 w-5 relative overflow-hidden shrink-0"
                       loading="lazy"
@@ -62,12 +62,12 @@ const Root2: NextPage<Root2Type> = ({ className = "", property1 = 10 }) => {
                       Anaokulu Öğrenci Sayısı
                     </div>
                   </div>
-                  <div className="h-10 rounded-[10px] bg-[#f8f9f9] flex flex-col items-start justify-center !pt-0 !pb-0 !pl-2.5 !pr-2.5 box-border text-[#686f77]">
+                  <div className="h-10 rounded-[0.625rem] bg-[#f8f9f9] flex flex-col items-start justify-center !pt-0 !pb-0 !pl-2.5 !pr-2.5 box-border text-[#686f77]">
                     <div className="relative">Öğrenci Sayısı Giriniz</div>
                   </div>
                 </div>
                 <div className="self-stretch flex flex-row items-center justify-between gap-0 text-left">
-                  <div className="w-[249px] flex flex-row items-center justify-start gap-[9px]">
+                  <div className="w-[15.563rem] flex flex-row items-center justify-start gap-[0.563rem]">
                     <Image
                       className="h-5 w-5 relative overflow-hidden shrink-0"
                       loading="lazy"
@@ -81,12 +81,12 @@ const Root2: NextPage<Root2Type> = ({ className = "", property1 = 10 }) => {
                       İlkokul Öğrenci Sayısı
                     </div>
                   </div>
-                  <div className="h-10 rounded-[10px] bg-[#f8f9f9] flex flex-col items-start justify-center !pt-0 !pb-0 !pl-2.5 !pr-2.5 box-border text-right text-[#686f77]">
+                  <div className="h-10 rounded-[0.625rem] bg-[#f8f9f9] flex flex-col items-start justify-center !pt-0 !pb-0 !pl-2.5 !pr-2.5 box-border text-right text-[#686f77]">
                     <div className="relative">Öğrenci Sayısı Giriniz</div>
                   </div>
                 </div>
                 <div className="self-stretch flex flex-row items-center justify-between gap-0">
-                  <div className="w-[249px] flex flex-row items-center justify-start gap-[9px]">
+                  <div className="w-[15.563rem] flex flex-row items-center justify-start gap-[0.563rem]">
                     <Image
                       className="h-5 w-5 relative overflow-hidden shrink-0"
                       loading="lazy"
@@ -100,12 +100,12 @@ const Root2: NextPage<Root2Type> = ({ className = "", property1 = 10 }) => {
                       Ortaokul Öğrenci Sayısı
                     </div>
                   </div>
-                  <div className="h-10 w-[157px] rounded-[10px] bg-[#f8f9f9] flex flex-col items-start justify-center !pt-0 !pb-0 !pl-2.5 !pr-2.5 box-border text-[15px] text-[#27313c]">
+                  <div className="h-10 w-[9.813rem] rounded-[0.625rem] bg-[#f8f9f9] flex flex-col items-start justify-center !pt-0 !pb-0 !pl-2.5 !pr-2.5 box-border text-[0.938rem] text-[#27313c]">
                     <div className="relative">100</div>
                   </div>
                 </div>
                 <div className="self-stretch flex flex-row items-center justify-between gap-0 text-left">
-                  <div className="w-[249px] flex flex-row items-center justify-start gap-[9px]">
+                  <div className="w-[15.563rem] flex flex-row items-center justify-start gap-[0.563rem]">
                     <Image
                       className="h-5 w-5 relative overflow-hidden shrink-0"
                       loading="lazy"
@@ -119,7 +119,7 @@ const Root2: NextPage<Root2Type> = ({ className = "", property1 = 10 }) => {
                       Lise Öğrenci Sayısı
                     </div>
                   </div>
-                  <div className="h-10 w-[157px] rounded-[10px] bg-[#f8f9f9] flex flex-col items-start justify-center !pt-0 !pb-0 !pl-2.5 !pr-2.5 box-border text-right text-[15px] text-[#27313c]">
+                  <div className="h-10 w-[9.813rem] rounded-[0.625rem] bg-[#f8f9f9] flex flex-col items-start justify-center !pt-0 !pb-0 !pl-2.5 !pr-2.5 box-border text-right text-[0.938rem] text-[#27313c]">
                     <div className="relative">250</div>
                   </div>
                 </div>

--- a/components/s.tsx
+++ b/components/s.tsx
@@ -9,12 +9,12 @@ export type SType = {
 const S: NextPage<SType> = ({ className = "", adSoyad, adSoyadnzGiriniz }) => {
   return (
     <div
-      className={`self-stretch flex flex-col items-start justify-center gap-[3px] text-right text-[13px] text-[#686f77] font-[Poppins] ${className}`}
+      className={`self-stretch flex flex-col items-start justify-center gap-[0.188rem] text-right text-[0.813rem] text-[#686f77] font-[Poppins] ${className}`}
     >
-      <header className="self-stretch relative text-[15px] font-medium font-[Poppins] text-[#27313c] text-left">
+      <header className="self-stretch relative text-[0.938rem] font-medium font-[Poppins] text-[#27313c] text-left">
         {adSoyad}
       </header>
-      <div className="self-stretch h-10 rounded-[10px] bg-[#f8f9f9] border-[#e6eff3] border-solid border-[1px] box-border flex flex-col items-start justify-center !pt-0 !pb-0 !pl-2.5 !pr-2.5">
+      <div className="self-stretch h-10 rounded-[0.625rem] bg-[#f8f9f9] border-[#e6eff3] border-solid border-[0.063rem] box-border flex flex-col items-start justify-center !pt-0 !pb-0 !pl-2.5 !pr-2.5">
         <div className="relative">{adSoyadnzGiriniz}</div>
       </div>
     </div>

--- a/components/secondary-nav-button.tsx
+++ b/components/secondary-nav-button.tsx
@@ -15,7 +15,7 @@ const SecondaryNavButton: NextPage<SecondaryNavButtonType> = ({
 }) => {
   return (
     <div
-      className={`h-[42px] w-[122px] rounded-[5px] bg-[rgba(158,92,247,0.15)] flex flex-row items-center justify-center !pt-0 !pb-0 !pl-10 !pr-10 box-border text-center text-[13px] text-[#9e5cf7] font-[Poppins] ${className}`}
+      className={`h-[2.625rem] w-[7.625rem] rounded-[0.313rem] bg-[rgba(158,92,247,0.15)] flex flex-row items-center justify-center !pt-0 !pb-0 !pl-10 !pr-10 box-border text-center text-[0.813rem] text-[#9e5cf7] font-[Poppins] ${className}`}
       data-property1={property1}
     >
       <div className="relative font-semibold">{tEXT}</div>

--- a/components/soru.tsx
+++ b/components/soru.tsx
@@ -14,12 +14,12 @@ const Soru: NextPage<SoruType> = ({ className = "", property1 = 0 }) => {
       className={`w-[48.75rem] overflow-hidden shrink-0 flex flex-col items-center justify-center gap-[0.625rem] text-left text-[0.938rem] text-[#27313c] font-[Poppins] ${className}`}
       data-property1={property1}
     >
-      <div className="self-stretch h-[3.125rem] rounded-[10px] bg-[#fff] border-[#e6eff3] border-solid border-[1px] box-border overflow-hidden shrink-0 flex flex-row items-center justify-between !pt-[1.062rem] !pb-[1.062rem] !pl-[1.562rem] !pr-[1.562rem] gap-[0rem]">
+      <div className="self-stretch h-[3.125rem] rounded-[0.625rem] bg-[#fff] border-[#e6eff3] border-solid border-[0.063rem] box-border overflow-hidden shrink-0 flex flex-row items-center justify-between !pt-[1.062rem] !pb-[1.062rem] !pl-[1.562rem] !pr-[1.562rem] gap-[0rem]">
         <div className="relative font-medium">
           1.  Ebtex’i kullanabilmek için hangi cihazlara ihtiyacım var?
         </div>
         <Image
-          className="h-[2.063rem] w-[2.063rem] relative rounded-[16.5px]"
+          className="h-[2.063rem] w-[2.063rem] relative rounded-[1.031rem]"
           loading="lazy"
           width={33}
           height={33}
@@ -28,12 +28,12 @@ const Soru: NextPage<SoruType> = ({ className = "", property1 = 0 }) => {
           src="/ekle2.svg"
         />
       </div>
-      <div className="self-stretch h-[3.125rem] rounded-[10px] bg-[#fff] border-[#e6eff3] border-solid border-[1px] box-border overflow-hidden shrink-0 flex flex-row items-center justify-between !pt-[1.062rem] !pb-[1.062rem] !pl-[1.562rem] !pr-[1.562rem] gap-[0rem]">
+      <div className="self-stretch h-[3.125rem] rounded-[0.625rem] bg-[#fff] border-[#e6eff3] border-solid border-[0.063rem] box-border overflow-hidden shrink-0 flex flex-row items-center justify-between !pt-[1.062rem] !pb-[1.062rem] !pl-[1.562rem] !pr-[1.562rem] gap-[0rem]">
         <div className="relative font-medium">
           2.  Ebtex kullanımını nasıl öğrenebilirim?
         </div>
         <Image
-          className="h-[2.063rem] w-[2.063rem] relative rounded-[16.5px]"
+          className="h-[2.063rem] w-[2.063rem] relative rounded-[1.031rem]"
           loading="lazy"
           width={33}
           height={33}
@@ -42,12 +42,12 @@ const Soru: NextPage<SoruType> = ({ className = "", property1 = 0 }) => {
           src="/ekle2.svg"
         />
       </div>
-      <div className="self-stretch h-[3.125rem] rounded-[10px] bg-[#fff] border-[#e6eff3] border-solid border-[1px] box-border overflow-hidden shrink-0 flex flex-row items-center justify-between !pt-[1.062rem] !pb-[1.062rem] !pl-[1.562rem] !pr-[1.562rem] gap-[0rem]">
+      <div className="self-stretch h-[3.125rem] rounded-[0.625rem] bg-[#fff] border-[#e6eff3] border-solid border-[0.063rem] box-border overflow-hidden shrink-0 flex flex-row items-center justify-between !pt-[1.062rem] !pb-[1.062rem] !pl-[1.562rem] !pr-[1.562rem] gap-[0rem]">
         <div className="relative font-medium">
           3.  Ebtex için ödediğim ücretle sistemi mi satın alıyorum?
         </div>
         <Image
-          className="h-[2.063rem] w-[2.063rem] relative rounded-[16.5px]"
+          className="h-[2.063rem] w-[2.063rem] relative rounded-[1.031rem]"
           loading="lazy"
           width={33}
           height={33}
@@ -56,12 +56,12 @@ const Soru: NextPage<SoruType> = ({ className = "", property1 = 0 }) => {
           src="/ekle2.svg"
         />
       </div>
-      <div className="self-stretch h-[3.125rem] rounded-[10px] bg-[#fff] border-[#e6eff3] border-solid border-[1px] box-border overflow-hidden shrink-0 flex flex-row items-center justify-between !pt-[1.062rem] !pb-[1.062rem] !pl-[1.562rem] !pr-[1.562rem] gap-[0rem]">
+      <div className="self-stretch h-[3.125rem] rounded-[0.625rem] bg-[#fff] border-[#e6eff3] border-solid border-[0.063rem] box-border overflow-hidden shrink-0 flex flex-row items-center justify-between !pt-[1.062rem] !pb-[1.062rem] !pl-[1.562rem] !pr-[1.562rem] gap-[0rem]">
         <div className="relative font-medium">
           4.  Ebtex güncelleniyor mu, bunun için ek ücret ödemem gerekir mi?
         </div>
         <Image
-          className="h-[2.063rem] w-[2.063rem] relative rounded-[16.5px]"
+          className="h-[2.063rem] w-[2.063rem] relative rounded-[1.031rem]"
           loading="lazy"
           width={33}
           height={33}
@@ -70,12 +70,12 @@ const Soru: NextPage<SoruType> = ({ className = "", property1 = 0 }) => {
           src="/ekle2.svg"
         />
       </div>
-      <div className="self-stretch h-[3.125rem] rounded-[10px] bg-[#fff] border-[#e6eff3] border-solid border-[1px] box-border overflow-hidden shrink-0 flex flex-row items-center justify-between !pt-[1.062rem] !pb-[1.062rem] !pl-[1.562rem] !pr-[1.562rem] gap-[0rem]">
+      <div className="self-stretch h-[3.125rem] rounded-[0.625rem] bg-[#fff] border-[#e6eff3] border-solid border-[0.063rem] box-border overflow-hidden shrink-0 flex flex-row items-center justify-between !pt-[1.062rem] !pb-[1.062rem] !pl-[1.562rem] !pr-[1.562rem] gap-[0rem]">
         <div className="relative font-medium">
           5.  Ebtex’te kaç kullanıcı ekleyebilirim?
         </div>
         <Image
-          className="h-[2.063rem] w-[2.063rem] relative rounded-[16.5px]"
+          className="h-[2.063rem] w-[2.063rem] relative rounded-[1.031rem]"
           loading="lazy"
           width={33}
           height={33}
@@ -84,12 +84,12 @@ const Soru: NextPage<SoruType> = ({ className = "", property1 = 0 }) => {
           src="/ekle2.svg"
         />
       </div>
-      <div className="self-stretch h-[3.125rem] rounded-[10px] bg-[#fff] border-[#e6eff3] border-solid border-[1px] box-border overflow-hidden shrink-0 flex flex-row items-center justify-between !pt-[1.062rem] !pb-[1.062rem] !pl-[1.562rem] !pr-[1.562rem] gap-[0rem]">
+      <div className="self-stretch h-[3.125rem] rounded-[0.625rem] bg-[#fff] border-[#e6eff3] border-solid border-[0.063rem] box-border overflow-hidden shrink-0 flex flex-row items-center justify-between !pt-[1.062rem] !pb-[1.062rem] !pl-[1.562rem] !pr-[1.562rem] gap-[0rem]">
         <div className="relative font-medium">
           6.  Ebtex kullanırken destek alabilir miyim?
         </div>
         <Image
-          className="h-[2.063rem] w-[2.063rem] relative rounded-[16.5px]"
+          className="h-[2.063rem] w-[2.063rem] relative rounded-[1.031rem]"
           loading="lazy"
           width={33}
           height={33}

--- a/components/soru1.tsx
+++ b/components/soru1.tsx
@@ -14,12 +14,12 @@ const Soru1: NextPage<Soru1Type> = ({ className = "", property1 = 0 }) => {
       className={`w-[48.75rem] flex flex-col items-center justify-center gap-[0.625rem] text-left text-[0.938rem] text-[#27313c] font-[Poppins] ${className}`}
       data-property1={property1}
     >
-      <div className="self-stretch h-[3.125rem] rounded-[10px] bg-[#fff] border-[#e6eff3] border-solid border-[1px] box-border overflow-hidden shrink-0 flex flex-row items-center justify-between !pt-[1.062rem] !pb-[1.062rem] !pl-[1.562rem] !pr-[1.562rem] gap-[0rem]">
+      <div className="self-stretch h-[3.125rem] rounded-[0.625rem] bg-[#fff] border-[#e6eff3] border-solid border-[0.063rem] box-border overflow-hidden shrink-0 flex flex-row items-center justify-between !pt-[1.062rem] !pb-[1.062rem] !pl-[1.562rem] !pr-[1.562rem] gap-[0rem]">
         <div className="relative font-medium">
           7.  Ebtex diğer sistemlerle entegre olabilir mi?
         </div>
         <Image
-          className="h-[2.063rem] w-[2.063rem] relative rounded-[16.5px]"
+          className="h-[2.063rem] w-[2.063rem] relative rounded-[1.031rem]"
           loading="lazy"
           width={33}
           height={33}
@@ -28,12 +28,12 @@ const Soru1: NextPage<Soru1Type> = ({ className = "", property1 = 0 }) => {
           src="/ekle2.svg"
         />
       </div>
-      <div className="self-stretch h-[3.125rem] rounded-[10px] bg-[#fff] border-[#e6eff3] border-solid border-[1px] box-border overflow-hidden shrink-0 flex flex-row items-center justify-between !pt-[1.062rem] !pb-[1.062rem] !pl-[1.562rem] !pr-[1.562rem] gap-[0rem]">
+      <div className="self-stretch h-[3.125rem] rounded-[0.625rem] bg-[#fff] border-[#e6eff3] border-solid border-[0.063rem] box-border overflow-hidden shrink-0 flex flex-row items-center justify-between !pt-[1.062rem] !pb-[1.062rem] !pl-[1.562rem] !pr-[1.562rem] gap-[0rem]">
         <div className="relative font-medium">
           8.  Ebtex güvenli mi, bilgilerim kaybolur mu?
         </div>
         <Image
-          className="h-[2.063rem] w-[2.063rem] relative rounded-[16.5px]"
+          className="h-[2.063rem] w-[2.063rem] relative rounded-[1.031rem]"
           loading="lazy"
           width={33}
           height={33}
@@ -42,12 +42,12 @@ const Soru1: NextPage<Soru1Type> = ({ className = "", property1 = 0 }) => {
           src="/ekle2.svg"
         />
       </div>
-      <div className="self-stretch h-[3.125rem] rounded-[10px] bg-[#fff] border-[#e6eff3] border-solid border-[1px] box-border overflow-hidden shrink-0 flex flex-row items-center justify-between !pt-[1.062rem] !pb-[1.062rem] !pl-[1.562rem] !pr-[1.562rem] gap-[0rem]">
+      <div className="self-stretch h-[3.125rem] rounded-[0.625rem] bg-[#fff] border-[#e6eff3] border-solid border-[0.063rem] box-border overflow-hidden shrink-0 flex flex-row items-center justify-between !pt-[1.062rem] !pb-[1.062rem] !pl-[1.562rem] !pr-[1.562rem] gap-[0rem]">
         <div className="relative font-medium">
           9. Kullanıcıların sistemdeki yetkileri kontrol edilebilir mi?
         </div>
         <Image
-          className="h-[2.063rem] w-[2.063rem] relative rounded-[16.5px]"
+          className="h-[2.063rem] w-[2.063rem] relative rounded-[1.031rem]"
           loading="lazy"
           width={33}
           height={33}
@@ -56,12 +56,12 @@ const Soru1: NextPage<Soru1Type> = ({ className = "", property1 = 0 }) => {
           src="/ekle2.svg"
         />
       </div>
-      <div className="self-stretch h-[3.125rem] rounded-[10px] bg-[#fff] border-[#e6eff3] border-solid border-[1px] box-border overflow-hidden shrink-0 flex flex-row items-center justify-between !pt-[1.062rem] !pb-[1.062rem] !pl-[1.562rem] !pr-[1.562rem] gap-[0rem]">
+      <div className="self-stretch h-[3.125rem] rounded-[0.625rem] bg-[#fff] border-[#e6eff3] border-solid border-[0.063rem] box-border overflow-hidden shrink-0 flex flex-row items-center justify-between !pt-[1.062rem] !pb-[1.062rem] !pl-[1.562rem] !pr-[1.562rem] gap-[0rem]">
         <div className="relative font-medium">
           10.  Çok şubeli kurumlarda tüm şubeleri yönetebilir miyim?
         </div>
         <Image
-          className="h-[2.063rem] w-[2.063rem] relative rounded-[16.5px]"
+          className="h-[2.063rem] w-[2.063rem] relative rounded-[1.031rem]"
           loading="lazy"
           width={33}
           height={33}
@@ -70,12 +70,12 @@ const Soru1: NextPage<Soru1Type> = ({ className = "", property1 = 0 }) => {
           src="/ekle2.svg"
         />
       </div>
-      <div className="self-stretch h-[3.125rem] rounded-[10px] bg-[#fff] border-[#e6eff3] border-solid border-[1px] box-border overflow-hidden shrink-0 flex flex-row items-center justify-between !pt-[1.062rem] !pb-[1.062rem] !pl-[1.562rem] !pr-[1.562rem] gap-[0rem]">
+      <div className="self-stretch h-[3.125rem] rounded-[0.625rem] bg-[#fff] border-[#e6eff3] border-solid border-[0.063rem] box-border overflow-hidden shrink-0 flex flex-row items-center justify-between !pt-[1.062rem] !pb-[1.062rem] !pl-[1.562rem] !pr-[1.562rem] gap-[0rem]">
         <div className="relative font-medium">
           11.  Ebtex’i mobil cihazlarda kullanabilir miyim?
         </div>
         <Image
-          className="h-[2.063rem] w-[2.063rem] relative rounded-[16.5px]"
+          className="h-[2.063rem] w-[2.063rem] relative rounded-[1.031rem]"
           loading="lazy"
           width={33}
           height={33}
@@ -84,12 +84,12 @@ const Soru1: NextPage<Soru1Type> = ({ className = "", property1 = 0 }) => {
           src="/ekle2.svg"
         />
       </div>
-      <div className="self-stretch h-[3.125rem] rounded-[10px] bg-[#fff] border-[#e6eff3] border-solid border-[1px] box-border overflow-hidden shrink-0 flex flex-row items-center justify-between !pt-[1.062rem] !pb-[1.062rem] !pl-[1.562rem] !pr-[1.562rem] gap-[0rem]">
+      <div className="self-stretch h-[3.125rem] rounded-[0.625rem] bg-[#fff] border-[#e6eff3] border-solid border-[0.063rem] box-border overflow-hidden shrink-0 flex flex-row items-center justify-between !pt-[1.062rem] !pb-[1.062rem] !pl-[1.562rem] !pr-[1.562rem] gap-[0rem]">
         <div className="relative font-medium">
           12. Ebtex’in diğer eğitim yazılımlarından farkı nedir?
         </div>
         <Image
-          className="h-[2.063rem] w-[2.063rem] relative rounded-[16.5px]"
+          className="h-[2.063rem] w-[2.063rem] relative rounded-[1.031rem]"
           loading="lazy"
           width={33}
           height={33}

--- a/components/website.tsx
+++ b/components/website.tsx
@@ -8,20 +8,20 @@ export type WebsiteType = {
 const Website: NextPage<WebsiteType> = ({ className = "" }) => {
   return (
     <div
-      className={`w-full max-w-[1920px] mx-auto h-[632px] bg-[#e9ecfb] flex flex-col items-center justify-start !pt-[70px] !pb-[97px] !pl-5 !pr-[21px] box-border gap-[30px] leading-[normal] tracking-[normal] text-center text-base text-[#5c67f7] font-[Poppins] ${className}`}
+      className={`w-full max-w-[120rem] mx-auto h-[39.5rem] bg-[#e9ecfb] flex flex-col items-center justify-start !pt-[4.375rem] !pb-[6.063rem] !pl-5 !pr-[1.313rem] box-border gap-[1.875rem] leading-[normal] tracking-[normal] text-center text-base text-[#5c67f7] font-[Poppins] ${className}`}
     >
-      <div className="flex flex-row items-start justify-end !pt-0 !pb-0 !pl-[367px] !pr-[365px] box-border max-w-full mq450:!pl-5 mq450:!pr-5 mq450:box-border">
+      <div className="flex flex-row items-start justify-end !pt-0 !pb-0 !pl-[22.938rem] !pr-[22.813rem] box-border max-w-full mq450:!pl-5 mq450:!pr-5 mq450:box-border">
         <div className="h-6 flex flex-col items-center justify-center">
-          <div className="self-stretch relative border-[#5c67f7] border-solid border-t-[2px] box-border h-0.5" />
+          <div className="self-stretch relative border-[#5c67f7] border-solid border-t-[0.125rem] box-border h-0.5" />
           <div className="relative font-medium">Hakkımızda</div>
         </div>
       </div>
-      <section className="w-[827px] flex flex-col items-start justify-start max-w-full z-[1] text-left text-2xl text-[#27313c] font-[Poppins]">
+      <section className="w-[51.688rem] flex flex-col items-start justify-start max-w-full z-[1] text-left text-2xl text-[#27313c] font-[Poppins]">
         <div className="flex flex-col items-start justify-start gap-2.5">
-          <h3 className="!m-0 relative text-[length:inherit] font-medium font-[inherit] mq450:text-[19px]">
+          <h3 className="!m-0 relative text-[length:inherit] font-medium font-[inherit] mq450:text-[1.188rem]">
             Eğitimde Güvenilir ve Yenilikçi Çözüm Ortağınız
           </h3>
-          <div className="relative text-[15px]">
+          <div className="relative text-[0.938rem]">
             <p className="!m-0">
               EBTEX, TAK Eğitim Teknolojileri Şirketi bünyesinde eğitim
               kurumlarının süreçlerini kolaylaştırmak ve öğrenci
@@ -39,12 +39,12 @@ const Website: NextPage<WebsiteType> = ({ className = "" }) => {
         </div>
       </section>
       <section className="flex flex-col items-start justify-start gap-2.5 max-w-full text-left text-2xl text-[#27313c] font-[Poppins]">
-        <h3 className="!m-0 self-stretch relative text-[length:inherit] font-medium font-[inherit] mq450:text-[19px]">
+        <h3 className="!m-0 self-stretch relative text-[length:inherit] font-medium font-[inherit] mq450:text-[1.188rem]">
           Değerlerimiz ve Yaklaşımlarımız
         </h3>
-        <div className="w-[826px] flex flex-row items-end justify-start gap-0.5 text-[15px]">
+        <div className="w-[51.625rem] flex flex-row items-end justify-start gap-0.5 text-[0.938rem]">
           <div className="flex flex-col items-start justify-end !pt-0 !pb-px !pl-0 !pr-0">
-            <div className="flex flex-col items-start justify-start gap-[38px]">
+            <div className="flex flex-col items-start justify-start gap-[2.375rem]">
               <Image
                 className="w-5 h-5 relative"
                 loading="lazy"
@@ -85,7 +85,7 @@ const Website: NextPage<WebsiteType> = ({ className = "" }) => {
           </div>
           <div className="flex flex-row items-start justify-start">
             <div className="flex flex-col items-start justify-start gap-3">
-              <div className="w-[795px] relative inline-block">
+              <div className="w-[49.688rem] relative inline-block">
                 <p className="!m-0">
                   <span className="font-[Poppins]">
                     Güvenilirlik ve Gizlilik:
@@ -98,7 +98,7 @@ const Website: NextPage<WebsiteType> = ({ className = "" }) => {
                 </p>
                 <p className="!m-0">zaman önem veririz.</p>
               </div>
-              <div className="w-[794px] relative inline-block">
+              <div className="w-[49.625rem] relative inline-block">
                 <p className="!m-0">
                   <span className="font-[Poppins]">{`Yenilikçilik ve Kalite: `}</span>
                   <span>
@@ -108,7 +108,7 @@ const Website: NextPage<WebsiteType> = ({ className = "" }) => {
                 </p>
                 <p className="!m-0">kaliteli çözümler sunuyoruz.</p>
               </div>
-              <div className="w-[804px] relative inline-block">
+              <div className="w-[50.25rem] relative inline-block">
                 <p className="!m-0">
                   <span className="font-[Poppins]">{`Kullanıcı Dostu Çözümler: `}</span>
                   <span>
@@ -118,7 +118,7 @@ const Website: NextPage<WebsiteType> = ({ className = "" }) => {
                 </p>
                 <p className="!m-0">arayüzler geliştiriyoruz.</p>
               </div>
-              <div className="w-[745px] relative inline-block">
+              <div className="w-[46.563rem] relative inline-block">
                 <span>{`7/24 Destek: `}</span>
                 <span>
                   Yıl boyunca her an yanınızda olan uzman ekibimizle, hızlı ve

--- a/components/website1.tsx
+++ b/components/website1.tsx
@@ -8,28 +8,28 @@ export type Website1Type = {
 const Website1: NextPage<Website1Type> = ({ className = "" }) => {
   return (
     <div
-      className={`w-full max-w-[1920px] mx-auto h-[861px] bg-[#f9fafc] overflow-hidden flex flex-col items-center justify-start !pt-[70px] !pb-[70px] !pl-5 !pr-5 box-border gap-[50px] leading-[normal] tracking-[normal] text-center text-base text-[#5c67f7] font-[Poppins] ${className}`}
+      className={`w-full max-w-[120rem] mx-auto h-[53.813rem] bg-[#f9fafc] overflow-hidden flex flex-col items-center justify-start !pt-[4.375rem] !pb-[4.375rem] !pl-5 !pr-5 box-border gap-[3.125rem] leading-[normal] tracking-[normal] text-center text-base text-[#5c67f7] font-[Poppins] ${className}`}
     >
-      <div className="flex flex-row items-start justify-start !pt-0 !pb-0 !pl-[543px] !pr-[543px] box-border max-w-full mq450:!pl-5 mq450:!pr-5 mq450:box-border">
+      <div className="flex flex-row items-start justify-start !pt-0 !pb-0 !pl-[33.938rem] !pr-[33.938rem] box-border max-w-full mq450:!pl-5 mq450:!pr-5 mq450:box-border">
         <div className="self-stretch flex flex-col items-start justify-start gap-2.5 max-w-full">
-          <div className="flex flex-row items-start justify-start !pt-0 !pb-0 !pl-[234px] !pr-[234px] mq450:!pl-5 mq450:!pr-5 mq450:box-border">
+          <div className="flex flex-row items-start justify-start !pt-0 !pb-0 !pl-[14.625rem] !pr-[14.625rem] mq450:!pl-5 mq450:!pr-5 mq450:box-border">
             <div className="h-6 flex flex-col items-center justify-center">
-              <div className="self-stretch relative border-[#5c67f7] border-solid border-t-[2px] box-border h-0.5" />
+              <div className="self-stretch relative border-[#5c67f7] border-solid border-t-[0.125rem] box-border h-0.5" />
               <div className="relative font-semibold">Modüllerimiz</div>
             </div>
           </div>
           <div className="flex-1 flex flex-col items-center justify-start max-w-full text-2xl text-[#27313c]">
-            <h3 className="!m-0 flex-1 relative text-[length:inherit] font-medium font-[inherit] mq450:text-[19px]">
+            <h3 className="!m-0 flex-1 relative text-[length:inherit] font-medium font-[inherit] mq450:text-[1.188rem]">
               EBTEX: Eğitim Kurumları İçin Kapsamlı Çözümler
             </h3>
-            <div className="w-[520px] relative text-sm font-medium text-[#6e829f] inline-block">
+            <div className="w-[32.5rem] relative text-sm font-medium text-[#6e829f] inline-block">
               Tüm eğitim süreçlerinizi kolayca yönetin, başarıyı artırın ve
               optimize edin
             </div>
           </div>
         </div>
       </div>
-      <main className="flex flex-col items-start justify-start gap-[30px] max-w-full text-left text-[15px] text-[#fff] font-[Poppins]">
+      <main className="flex flex-col items-start justify-start gap-[1.875rem] max-w-full text-left text-[0.938rem] text-[#fff] font-[Poppins]">
         <div className="self-stretch flex-1 flex flex-col items-start justify-start gap-2.5 max-w-full">
           <FrameComponent21
             group53="/group-53.svg"
@@ -62,8 +62,8 @@ const Website1: NextPage<Website1Type> = ({ className = "" }) => {
             burslulukYnetim="Rehberlik Takip"
           />
         </div>
-        <div className="flex flex-row items-start justify-start !pt-0 !pb-0 !pl-[734px] !pr-[734px] mq450:!pl-5 mq450:!pr-5 mq450:box-border">
-          <div className="rounded-md bg-[#5c67f7] flex flex-row items-center justify-center !pt-[7.5px] !pb-[7.5px] !pl-[15px] !pr-[15px]">
+        <div className="flex flex-row items-start justify-start !pt-0 !pb-0 !pl-[45.875rem] !pr-[45.875rem] mq450:!pl-5 mq450:!pr-5 mq450:box-border">
+          <div className="rounded-md bg-[#5c67f7] flex flex-row items-center justify-center !pt-[0.469rem] !pb-[0.469rem] !pl-[0.938rem] !pr-[0.938rem]">
             <div className="relative font-semibold">Tüm Modülleri Keşfet</div>
           </div>
         </div>

--- a/scripts/convert.js
+++ b/scripts/convert.js
@@ -1,0 +1,26 @@
+const fs = require('fs');
+const path = require('path');
+
+function convertPxToRem(content) {
+  return content.replace(/\[(-?\d*\.?\d+)px\]/g, (_, num) => {
+    const value = parseFloat(num) / 16;
+    const rounded = Math.round(value * 1000) / 1000;
+    return `[${rounded}rem]`;
+  });
+}
+
+function traverse(dir) {
+  for (const file of fs.readdirSync(dir)) {
+    const full = path.join(dir, file);
+    if (fs.statSync(full).isDirectory()) {
+      traverse(full);
+    } else if (/(tsx|jsx|ts|js|css)$/.test(file)) {
+      const content = fs.readFileSync(full, 'utf8');
+      const newContent = convertPxToRem(content);
+      if (newContent !== content) fs.writeFileSync(full, newContent);
+    }
+  }
+}
+
+traverse('components');
+traverse('app');


### PR DESCRIPTION
## Summary
- replace all Tailwind px utilities with rem units across components
- include conversion script `scripts/convert.js` for future updates

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68457e08a9fc832c9e7ed912e8da4e95