### PR TITLE
Open DestekMerkezi from module icons

### DIFF
--- a/app/website-design.tsx
+++ b/app/website-design.tsx
@@ -7,30 +7,44 @@ import Website from "../components/website";
 import Website1 from "../components/website1";
 import Frame2461 from "../components/frame246";
 import Root2 from "../components/root2";
-import Root3 from "./root3/root3"
+import Root3 from "./root3/root3";
 import Referanslarmz from "../components/referanslarmz";
 import MesajGnder from "../components/mesaj-gnder";
 import Footer from "../components/footer";
 import DestekMerkezi from "../components/destek-merkezi";
+import { useState } from "react";
 const WebsiteDesign: NextPage = () => {
+  const [showDestek, setShowDestek] = useState(false);
   return (
-     <>
-    <GrmeNavbarOn />
-    <div className="w-full relative flex flex-row items-start justify-start leading-[normal] tracking-[normal]">
-      <Component1 />
-    
-    </div>
-     <Root />
-     <Website />
-   <Website1 />
-         <Root1/>
-<Frame2461 />
-<Root2 />
-<Root3 />
-<Referanslarmz />
-<MesajGnder />
-<DestekMerkezi />
-<Footer />
+    <>
+      <GrmeNavbarOn />
+      <div className="w-full relative flex flex-row items-start justify-start leading-[normal] tracking-[normal]">
+        <Component1 />
+
+      </div>
+      <Root />
+      <Website />
+      <Website1 onModuleClick={() => setShowDestek(true)} />
+      <Root1 />
+      <Frame2461 />
+      <Root2 />
+      <Root3 />
+      <Referanslarmz />
+      <MesajGnder />
+      {showDestek && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50 overflow-auto">
+          <div className="relative w-full max-w-[90%] max-h-screen overflow-y-auto">
+            <button
+              className="absolute top-2 right-2 z-10 bg-white rounded-full w-8 h-8 flex items-center justify-center"
+              onClick={() => setShowDestek(false)}
+            >
+              X
+            </button>
+            <DestekMerkezi />
+          </div>
+        </div>
+      )}
+      <Footer />
     </>
   );
 };

--- a/components/frame-component2.tsx
+++ b/components/frame-component2.tsx
@@ -11,6 +11,7 @@ export type FrameComponent21Type = {
   yoklamaYnetim?: string;
   group533: string;
   burslulukYnetim?: string;
+  onModuleClick?: () => void;
 };
 
 const FrameComponent21: NextPage<FrameComponent21Type> = ({
@@ -21,15 +22,19 @@ const FrameComponent21: NextPage<FrameComponent21Type> = ({
   devTakip,
   group532,
   yoklamaYnetim,
-  
+
   group533,
   burslulukYnetim,
+  onModuleClick,
 }) => {
   return (
     <section
       className={`self-stretch flex-1 flex flex-row items-center justify-center gap-5 max-w-full text-center text-base text-[#27313c] font-[Poppins] ${className}`}
     >
-      <div className="h-[10.25rem] w-[25rem] shadow-[0px_4px_4px_rgba(0,_0,_0,_0.25)] rounded-[0.625rem] bg-[#fff] border-[#e6eff3] border-solid border-[0.125rem] box-border overflow-hidden shrink-0 flex flex-col items-center justify-center !p-2.5 gap-2.5 max-w-full">
+      <div
+        className="h-[10.25rem] w-[25rem] shadow-[0px_4px_4px_rgba(0,_0,_0,_0.25)] rounded-[0.625rem] bg-[#fff] border-[#e6eff3] border-solid border-[0.125rem] box-border overflow-hidden shrink-0 flex flex-col items-center justify-center !p-2.5 gap-2.5 max-w-full cursor-pointer"
+        onClick={onModuleClick}
+      >
         <Image
           className="w-[4.5rem] h-[4.5rem] relative"
           loading="lazy"
@@ -41,7 +46,10 @@ const FrameComponent21: NextPage<FrameComponent21Type> = ({
         />
         <div className="relative font-semibold">{soruHavuzu}</div>
       </div>
-      <div className="h-[10.25rem] w-[25rem] shadow-[0px_4px_4px_rgba(0,_0,_0,_0.25)] rounded-[0.625rem] bg-[#fff] border-[#e6eff3] border-solid border-[0.125rem] box-border overflow-hidden shrink-0 flex flex-col items-center justify-center !p-2.5 gap-2.5 max-w-full">
+      <div
+        className="h-[10.25rem] w-[25rem] shadow-[0px_4px_4px_rgba(0,_0,_0,_0.25)] rounded-[0.625rem] bg-[#fff] border-[#e6eff3] border-solid border-[0.125rem] box-border overflow-hidden shrink-0 flex flex-col items-center justify-center !p-2.5 gap-2.5 max-w-full cursor-pointer"
+        onClick={onModuleClick}
+      >
         <Image
           className="w-[4.5rem] h-[4.5rem] relative"
           loading="lazy"
@@ -53,7 +61,10 @@ const FrameComponent21: NextPage<FrameComponent21Type> = ({
         />
         <div className="relative font-semibold">{devTakip}</div>
       </div>
-      <div className="h-[10.25rem] w-[25rem] shadow-[0px_4px_4px_rgba(0,_0,_0,_0.25)] rounded-[0.625rem] bg-[#fff] border-[#e6eff3] border-solid border-[0.125rem] box-border overflow-hidden shrink-0 flex flex-col items-center justify-center !p-2.5 gap-2.5 max-w-full">
+      <div
+        className="h-[10.25rem] w-[25rem] shadow-[0px_4px_4px_rgba(0,_0,_0,_0.25)] rounded-[0.625rem] bg-[#fff] border-[#e6eff3] border-solid border-[0.125rem] box-border overflow-hidden shrink-0 flex flex-col items-center justify-center !p-2.5 gap-2.5 max-w-full cursor-pointer"
+        onClick={onModuleClick}
+      >
         <Image
           className="w-[4.5rem] h-[4.5rem] relative"
           loading="lazy"
@@ -65,7 +76,10 @@ const FrameComponent21: NextPage<FrameComponent21Type> = ({
         />
         <div className="relative font-semibold">{yoklamaYnetim}</div>
       </div>
-      <div className="h-[10.25rem] w-[25rem] shadow-[0px_4px_4px_rgba(0,_0,_0,_0.25)] rounded-[0.625rem] bg-[#fff] border-[#e6eff3] border-solid border-[0.125rem] box-border overflow-hidden shrink-0 flex flex-col items-center justify-center !p-2.5 gap-2.5 max-w-full">
+      <div
+        className="h-[10.25rem] w-[25rem] shadow-[0px_4px_4px_rgba(0,_0,_0,_0.25)] rounded-[0.625rem] bg-[#fff] border-[#e6eff3] border-solid border-[0.125rem] box-border overflow-hidden shrink-0 flex flex-col items-center justify-center !p-2.5 gap-2.5 max-w-full cursor-pointer"
+        onClick={onModuleClick}
+      >
         <Image
           className="w-[4.5rem] h-[4.5rem] relative"
           loading="lazy"

--- a/components/website1.tsx
+++ b/components/website1.tsx
@@ -3,9 +3,10 @@ import FrameComponent21 from "./frame-component2";
 
 export type Website1Type = {
   className?: string;
+  onModuleClick?: () => void;
 };
 
-const Website1: NextPage<Website1Type> = ({ className = "" }) => {
+const Website1: NextPage<Website1Type> = ({ className = "", onModuleClick }) => {
   return (
     <div
       className={`w-full max-w-[120rem] mx-auto h-[53.813rem] bg-[#f9fafc] overflow-hidden flex flex-col items-center justify-start !pt-[4.375rem] !pb-[4.375rem] !pl-5 !pr-5 box-border gap-[3.125rem] leading-[normal] tracking-[normal] text-center text-base text-[#5c67f7] font-[Poppins] ${className}`}
@@ -41,6 +42,7 @@ const Website1: NextPage<Website1Type> = ({ className = "" }) => {
             yoklamaYnetim="Yoklama Yönetim"
             group533="/group-53-3.svg"
             burslulukYnetim="Bursluluk Yönetim"
+            onModuleClick={onModuleClick}
           />
           <FrameComponent21
             className="mq450:flex-col"
@@ -52,6 +54,7 @@ const Website1: NextPage<Website1Type> = ({ className = "" }) => {
             yoklamaYnetim="Servis Ulaşım"
             group533="/group-53-7.svg"
             burslulukYnetim="Finans ve Muhasebe"
+            onModuleClick={onModuleClick}
           />
           <FrameComponent21
             className="mq450:flex-col"
@@ -63,6 +66,7 @@ const Website1: NextPage<Website1Type> = ({ className = "" }) => {
             yoklamaYnetim="Etkinlik Yönetimi"
             group533="/group-53-11.svg"
             burslulukYnetim="Rehberlik Takip"
+            onModuleClick={onModuleClick}
           />
         </div>
         <div className="flex flex-row items-start justify-start !pt-0 !pb-0 !pl-[45.875rem] !pr-[45.875rem] mq450:!pl-5 mq450:!pr-5 mq450:box-border">


### PR DESCRIPTION
## Summary
- add click handler prop to FrameComponent21
- expose `onModuleClick` in Website1 and hook up the modules
- show DestekMerkezi as a modal overlay when modules are clicked

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845a5840f14832c9218a9986d84ab28