### PR TITLE
Integrate Destek Merkezi component

### DIFF
--- a/app/website-design.tsx
+++ b/app/website-design.tsx
@@ -9,12 +9,16 @@ import Website1 from "../components/website1";
 import Frame2461 from "../components/frame246";
 import Root2 from "../components/root2";
 import Root3 from "./root3/root3";
+import DestekMerkezi from "../components/destek-merkezi";
 import Referanslarmz from "../components/referanslarmz";
 import MesajGnder from "../components/mesaj-gnder";
 import Footer from "../components/footer";
 import { useState } from "react";
 const WebsiteDesign: NextPage = () => {
   const [showDestek, setShowDestek] = useState(false);
+  if (showDestek) {
+    return <DestekMerkezi onBack={() => setShowDestek(false)} />;
+  }
   return (
     <>
       <GrmeNavbarOn />

--- a/components/destek-merkezi.tsx
+++ b/components/destek-merkezi.tsx
@@ -1,0 +1,283 @@
+"use client";
+import type { NextPage } from "next";
+import FrameComponent from "./destek-modules/frame-component";
+import PrimaryNavButton from "./destek-modules/primary-nav-button";
+import Header from "./destek-modules/header";
+
+export type DestekMerkeziProps = {
+  onBack?: () => void;
+};
+
+const DestekMerkezi: NextPage<DestekMerkeziProps> = ({ onBack }) => {
+  return (
+    <div className="destekMerkezi">
+      <Header />
+      <main className="destekMerkeziInner">
+        <section className="frameParent">
+          <FrameComponent onBack={onBack} />
+          <div className="frame">
+            <div className="anaFrame">
+              <section className="butonScroll">
+                <div className="butonlar">
+                  <PrimaryNavButton property1="default" tEXT="Soru Havuzu" />
+                  <PrimaryNavButton
+                    property1="default"
+                    primaryNavButtonAlignSelf="stretch"
+                    primaryNavButtonWidth="unset"
+                    tEXT="Ödev Takip"
+                  />
+                  <PrimaryNavButton
+                    property1="default"
+                    primaryNavButtonAlignSelf="stretch"
+                    primaryNavButtonWidth="unset"
+                    tEXT="Yoklama Yönetimi"
+                  />
+                  <PrimaryNavButton
+                    property1="default"
+                    primaryNavButtonAlignSelf="stretch"
+                    primaryNavButtonWidth="unset"
+                    tEXT="Çevrimiçi Sınav"
+                  />
+                  <PrimaryNavButton
+                    property1="default"
+                    primaryNavButtonAlignSelf="stretch"
+                    primaryNavButtonWidth="unset"
+                    tEXT="Servis Ulaşım"
+                  />
+                  <PrimaryNavButton
+                    property1="default"
+                    primaryNavButtonAlignSelf="stretch"
+                    primaryNavButtonWidth="unset"
+                    tEXT="Ders Defteri"
+                  />
+                  <PrimaryNavButton
+                    property1="default"
+                    primaryNavButtonAlignSelf="stretch"
+                    primaryNavButtonWidth="unset"
+                    tEXT="Etkinlik Yönetimi"
+                  />
+                  <PrimaryNavButton
+                    property1="default"
+                    primaryNavButtonAlignSelf="stretch"
+                    primaryNavButtonWidth="unset"
+                    tEXT="Rehberlik Takip"
+                  />
+                  <PrimaryNavButton
+                    property1="default"
+                    primaryNavButtonAlignSelf="stretch"
+                    primaryNavButtonWidth="unset"
+                    tEXT="Raporlamalar"
+                  />
+                  <PrimaryNavButton
+                    property1="default"
+                    primaryNavButtonAlignSelf="stretch"
+                    primaryNavButtonWidth="unset"
+                    tEXT="Kütüphane Yönetimi"
+                  />
+                </div>
+              </section>
+              <div className="erik">
+                <div className="destekMerkeziEbtexContainer">
+                  <p className="blankLine">
+                    <span className="canlDestek">Destek Merkezi</span>
+                  </p>
+                  <p className="blankLine">
+                    <span>&nbsp;</span>
+                  </p>
+                  <p className="blankLine">
+                    <span>
+                      EBTEX Destek Merkezi Modülü, kullanıcıların sistem kullanımı
+                      sırasında karşılaştığı sorunları hızlıca bildirmelerini ve
+                      etkili çözümler sunulmasını sağlar.
+                    </span>
+                  </p>
+                  <p className="blankLine">
+                    <span>&nbsp;</span>
+                  </p>
+                  <ul className="canlDestekKullanclarnA">
+                    <li className="blankLine">
+                      <span className="canlDestek">Canlı Destek:</span>
+                      <span className="canlDestek">
+                        {" "}
+                        Kullanıcıların anlık sorunlarına hızlı yanıt almak için sistem
+                        yöneticileriyle gerçek zamanlı sohbet etmesini sağlar.
+                      </span>
+                    </li>
+                    <p className="blankLine">
+                      <span className="canlDestek">Destek Talebi Yönetimi:</span>
+                      <span className="canlDestek">
+                        {" "}
+                        Kullanıcılar, yaşadıkları teknik sorunları, ödeme problemlerini
+                        veya kurslarla ilgili sorularını destek talepleri olarak iletir,
+                        bu talepler sistematik olarak kayıt altına alınır ve takip edilir.
+                      </span>
+                    </p>
+                    <p className="blankLine">
+                      <span className="canlDestek">Uzman Yönlendirme:</span>
+                      <span className="canlDestek">
+                        {" "}
+                        Destek talepleri, konuya göre kategorize edilerek ilgili uzmanlara
+                        otomatik olarak yönlendirilir ve hızlı çözüm sağlanır.
+                      </span>
+                    </p>
+                    <p className="blankLine">
+                      <span className="canlDestek">Dosya ve Eklenti Yönetimi:</span>
+                      <span className="canlDestek">
+                        {" "}
+                        Kullanıcılar destek taleplerine sorunlarını açıklayan belgeler,
+                        görseller veya diğer dosyaları ekleyerek sorunun daha hızlı
+                        anlaşılmasını sağlar.
+                      </span>
+                    </p>
+                    <p className="blankLine">
+                      <span className="canlDestek">Talep Durumu Takibi:</span>
+                      <span className="canlDestek">
+                        {" "}
+                        Kullanıcılar, destek taleplerinin güncel durumunu (incelemede,
+                        çözüldü, beklemede gibi) sistem üzerinden takip edebilir.
+                      </span>
+                    </p>
+                    <p className="blankLine">
+                      <span className="canlDestek">Bildirim ve Güncellemeler:</span>
+                      <span className="canlDestek">
+                        {" "}
+                        Kullanıcılar, destek taleplerinin durumu değiştiğinde veya
+                        cevaplandığında otomatik olarak bilgilendirilir.
+                      </span>
+                    </p>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+      </main>
+      <style jsx>{`
+      .butonlar {
+        height: 72.438rem;
+        width: 12.5rem;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: flex-start;
+        gap: var(--gap-10);
+      }
+      .butonScroll {
+        height: 45.875rem;
+        overflow-y: auto;
+        display: flex;
+        flex-direction: row;
+        align-items: flex-start;
+        justify-content: center;
+      }
+      .blankLine {
+        margin: 0;
+      }
+      .canlDestek {
+        font-family: var(--font-poppins);
+      }
+      .canlDestekKullanclarnA {
+        margin: 0;
+        font-size: inherit;
+        padding-left: 1.35rem;
+      }
+      .destekMerkeziEbtexContainer {
+        width: 82.75rem;
+        position: relative;
+        display: inline-block;
+        flex-shrink: 0;
+      }
+      .anaFrame,
+      .erik {
+        border-radius: var(--br-10);
+        display: flex;
+        flex-direction: row;
+        align-items: flex-start;
+        justify-content: center;
+        box-sizing: border-box;
+        max-width: 100%;
+      }
+      .erik {
+        height: 43.688rem;
+        border: 2px solid var(--color-aliceblue);
+        padding: var(--padding-15) 1.437rem;
+      }
+      .anaFrame {
+        align-self: stretch;
+        flex: 1;
+        background-color: var(--color-white);
+        padding: 1.562rem 2.812rem 0;
+        gap: 2.187rem;
+      }
+      .frame {
+        flex: 1;
+        flex-direction: column;
+        justify-content: flex-start;
+      }
+      .destekMerkeziInner,
+      .frame,
+      .frameParent {
+        align-self: stretch;
+        display: flex;
+        align-items: flex-start;
+        max-width: 100%;
+      }
+      .frameParent {
+        flex-direction: column;
+        justify-content: flex-start;
+        gap: var(--gap-15);
+        text-align: left;
+        font-size: 1.25rem;
+        font-family: var(--font-poppins);
+      }
+      .destekMerkeziInner {
+        flex-direction: row;
+        justify-content: center;
+        padding: 0 var(--padding-20) 0 1.312rem;
+        box-sizing: border-box;
+      }
+      .destekMerkezi {
+        width: 100%;
+        position: relative;
+        background-color: var(--color-whitesmoke);
+        display: flex;
+        flex-direction: column;
+        align-items: flex-end;
+        justify-content: flex-start;
+        padding: 0 0 3.125rem;
+        box-sizing: border-box;
+        gap: 3.125rem;
+        line-height: normal;
+        letter-spacing: normal;
+      }
+      @media screen and (max-width: 1650px) {
+        .anaFrame {
+          flex-wrap: wrap;
+        }
+      }
+      @media screen and (max-width: 1300px) {
+        .anaFrame {
+          padding-left: var(--padding-22);
+          padding-right: var(--padding-22);
+          box-sizing: border-box;
+        }
+      }
+      @media screen and (max-width: 900px) {
+        .anaFrame {
+          gap: 1.063rem;
+        }
+        .destekMerkezi {
+          gap: 1.563rem;
+        }
+      }
+      @media screen and (max-width: 450px) {
+        .destekMerkeziEbtexContainer {
+          font-size: var(--font-size-16);
+        }
+      }
+    `}</style>
+    </div>
+  );
+};
+
+export default DestekMerkezi;

--- a/components/destek-modules/arkaplan.module.css
+++ b/components/destek-modules/arkaplan.module.css
@@ -1,0 +1,353 @@
+.wrapperFrame244,
+.wrapperFrame244Child {
+  align-self: stretch;
+  flex-shrink: 0;
+  overflow: hidden;
+}
+.wrapperFrame244Child {
+  height: 100%;
+  object-fit: cover;
+  position: absolute;
+  left: 0;
+  top: 0.125rem;
+  width: 100%;
+  transform: scale(1.736);
+}
+.wrapperFrame244 {
+  position: relative;
+  max-width: 100%;
+  height: 1.844rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.wrapperFrame245Child,
+.wrapperFrame62Child {
+  align-self: stretch;
+  height: 100%;
+  overflow: hidden;
+  flex-shrink: 0;
+  object-fit: cover;
+  position: absolute;
+  left: 0;
+  width: 100%;
+}
+.wrapperFrame62Child {
+  top: -0.125rem;
+  transform: scale(1.736);
+}
+.wrapperFrame245Child {
+  top: 0;
+  transform: scale(1.468);
+}
+.x {
+  position: absolute;
+  top: 23.019rem;
+  left: 107.25rem;
+  width: 1.844rem;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+  gap: 5.312rem;
+}
+.patternChild {
+  position: absolute;
+  top: 12.456rem;
+  left: 108.563rem;
+  width: 14.563rem;
+  height: 14.675rem;
+}
+.shapeContainersChild {
+  align-self: stretch;
+  position: relative;
+  border-radius: 50%;
+  background-color: var(--color-mediumslateblue-100);
+  height: 0.656rem;
+}
+.shapeContainers {
+  width: 0.656rem;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+  gap: 2.043rem;
+}
+.shapeContainersParent {
+  position: absolute;
+  top: 59.331rem;
+  left: 76.925rem;
+  filter: blur(5.2px);
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 2.781rem;
+}
+.patternItem {
+  position: absolute;
+  top: 0;
+  left: 73.194rem;
+  width: 21.963rem;
+  height: 20.288rem;
+  object-fit: contain;
+}
+.wrapperVector13Child {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  position: absolute;
+  left: 0;
+  top: 0;
+  transform: scale(1.047);
+}
+.wrapperVector13 {
+  position: absolute;
+  top: 56.844rem;
+  left: 1.75rem;
+  width: 22.2rem;
+  height: 22.2rem;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.patternInner,
+.vectorIcon {
+  position: absolute;
+  top: 17.244rem;
+  left: 0;
+  width: 37.688rem;
+  height: 37.688rem;
+}
+.vectorIcon {
+  top: 10.769rem;
+}
+.patternChild1 {
+  position: absolute;
+  top: 10.331rem;
+  left: 32.906rem;
+  border-radius: 50%;
+  background: linear-gradient(-90deg, #5a65ec, #626cec);
+  width: 20.844rem;
+  height: 20.844rem;
+}
+.circlesIcon {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  position: absolute;
+  left: 0;
+  top: 0;
+  transform: scale(1.023);
+}
+.wrapperCircles {
+  position: absolute;
+  top: 17.944rem;
+  left: 23.313rem;
+  width: 27.425rem;
+  height: 27.425rem;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.patternChild2 {
+  position: absolute;
+  top: 14.019rem;
+  left: 1.875rem;
+  width: 16.063rem;
+  height: 16.063rem;
+}
+.wrapperVector17Child {
+  width: 100%;
+  height: 100%;
+  z-index: 2;
+  object-fit: cover;
+  position: absolute;
+  left: 0;
+  top: 0;
+  transform: scale(1.26);
+}
+.wrapperVector17 {
+  width: 4.469rem;
+  position: relative;
+  height: 4.469rem;
+  z-index: 2;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.wrapperVector17Item {
+  height: 100%;
+  width: 100%;
+  object-fit: cover;
+  position: absolute;
+  left: 0.188rem;
+  top: 0;
+  transform: scale(1.1);
+}
+.wrapperVector171 {
+  height: 15.063rem;
+  width: 100%;
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.wrapperVector17Wrapper {
+  width: 15.813rem;
+  height: 15.063rem;
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  justify-content: flex-start;
+  padding: 0 0 0 var(--padding-12);
+  box-sizing: border-box;
+  z-index: 1;
+}
+.overlayElements,
+.overlayElementsWrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+}
+.overlayElements {
+  width: 15.813rem;
+  height: 20.313rem;
+  gap: 0.781rem;
+}
+.overlayElementsWrapper {
+  height: 25.438rem;
+  width: 16.313rem;
+  padding: 5.125rem var(--padding-8) 0 0;
+  box-sizing: border-box;
+  z-index: 2;
+}
+.wrapperVector18Child {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  position: absolute;
+  left: 0;
+  top: 0;
+  transform: scale(1.04);
+}
+.wrapperVector18 {
+  width: 100%;
+  position: relative;
+  height: 23.844rem;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.wrapperVector18Wrapper {
+  height: 25.031rem;
+  width: 27rem;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+  padding: var(--padding-19) 0 0;
+  box-sizing: border-box;
+  z-index: 1;
+}
+.wrapperVector20Child {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  position: absolute;
+  left: 0;
+  top: 0;
+  transform: scale(1.051);
+}
+.wrapperVector20 {
+  width: 19.5rem;
+  position: relative;
+  height: 19.5rem;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.frameGroup {
+  margin-top: -41.25rem;
+  width: 68.875rem;
+  height: 25.438rem;
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  justify-content: flex-start;
+  gap: 3.031rem;
+  flex-shrink: 0;
+  z-index: 2;
+}
+.wrapperVector14Child {
+  height: 100%;
+  width: 100%;
+  flex-shrink: 0;
+  object-fit: cover;
+  position: absolute;
+  left: 0;
+  top: 0;
+  transform: scale(1.033);
+}
+.wrapperVector14 {
+  height: 25.063rem;
+  width: 100%;
+  position: relative;
+  flex-shrink: 0;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.frameParent,
+.wrapperVector14Wrapper {
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-start;
+  box-sizing: border-box;
+}
+.wrapperVector14Wrapper {
+  width: 50.969rem;
+  height: 25.063rem;
+  flex-direction: row;
+  padding: 0 0 0 17.55rem;
+  z-index: 1;
+}
+.frameParent {
+  position: absolute;
+  top: 14.081rem;
+  left: 0.875rem;
+  width: 68.875rem;
+  height: 65.063rem;
+  flex-direction: column;
+  padding: 40rem 0 0;
+  gap: 15.812rem;
+}
+.pattern {
+  margin-left: -2.5rem;
+  margin-bottom: -2.375rem;
+  height: 79.144rem;
+  width: 123.125rem;
+  position: relative;
+  flex-shrink: 0;
+}
+.arkaplan {
+  position: absolute;
+  top: -11.25rem;
+  left: -3.75rem;
+  background-color: var(--color-mediumslateblue-300);
+  width: 120rem;
+  height: 62.5rem;
+  overflow: hidden;
+  display: flex;
+  flex-direction: row;
+  align-items: flex-end;
+  justify-content: flex-start;
+}

--- a/components/destek-modules/arkaplan.tsx
+++ b/components/destek-modules/arkaplan.tsx
@@ -1,0 +1,244 @@
+import type { NextPage } from "next";
+import Image from "next/image";
+import styles from "./arkaplan.module.css";
+
+export type ArkaplanType = {
+  className?: string;
+};
+
+const Arkaplan: NextPage<ArkaplanType> = ({ className = "" }) => {
+  return (
+    <div className={[styles.arkaplan, className].join(" ")}>
+      <div className={styles.pattern}>
+        <div className={styles.x}>
+          <div className={styles.wrapperFrame244}>
+            <Image
+              className={styles.wrapperFrame244Child}
+              width={29.5}
+              height={29.5}
+              sizes="100vw"
+              alt=""
+              src="/frame-244.svg"
+            />
+          </div>
+          <div className={styles.wrapperFrame244}>
+            <Image
+              className={styles.wrapperFrame62Child}
+              loading="lazy"
+              width={29.5}
+              height={29.5}
+              sizes="100vw"
+              alt=""
+              src="/frame-244.svg"
+            />
+          </div>
+          <div className={styles.wrapperFrame244}>
+            <Image
+              className={styles.wrapperFrame245Child}
+              loading="lazy"
+              width={29.5}
+              height={29.5}
+              sizes="100vw"
+              alt=""
+              src="/frame-244.svg"
+            />
+          </div>
+          <div className={styles.wrapperFrame244}>
+            <Image
+              className={styles.wrapperFrame245Child}
+              loading="lazy"
+              width={29.5}
+              height={29.5}
+              sizes="100vw"
+              alt=""
+              src="/frame-244.svg"
+            />
+          </div>
+          <div className={styles.wrapperFrame244}>
+            <Image
+              className={styles.wrapperFrame245Child}
+              loading="lazy"
+              width={29.5}
+              height={29.5}
+              sizes="100vw"
+              alt=""
+              src="/frame-244.svg"
+            />
+          </div>
+        </div>
+        <Image
+          className={styles.patternChild}
+          width={233}
+          height={234.8}
+          sizes="100vw"
+          alt=""
+          src="/vector-12.svg"
+        />
+        <div className={styles.shapeContainersParent}>
+          <div className={styles.shapeContainers}>
+            <div className={styles.shapeContainersChild} />
+            <div className={styles.shapeContainersChild} />
+            <div className={styles.shapeContainersChild} />
+            <div className={styles.shapeContainersChild} />
+          </div>
+          <div className={styles.shapeContainers}>
+            <div className={styles.shapeContainersChild} />
+            <div className={styles.shapeContainersChild} />
+            <div className={styles.shapeContainersChild} />
+            <div className={styles.shapeContainersChild} />
+          </div>
+          <div className={styles.shapeContainers}>
+            <div className={styles.shapeContainersChild} />
+            <div className={styles.shapeContainersChild} />
+            <div className={styles.shapeContainersChild} />
+            <div className={styles.shapeContainersChild} />
+          </div>
+          <div className={styles.shapeContainers}>
+            <div className={styles.shapeContainersChild} />
+            <div className={styles.shapeContainersChild} />
+            <div className={styles.shapeContainersChild} />
+            <div className={styles.shapeContainersChild} />
+          </div>
+          <div className={styles.shapeContainers}>
+            <div className={styles.shapeContainersChild} />
+            <div className={styles.shapeContainersChild} />
+            <div className={styles.shapeContainersChild} />
+            <div className={styles.shapeContainersChild} />
+          </div>
+          <div className={styles.shapeContainers}>
+            <div className={styles.shapeContainersChild} />
+            <div className={styles.shapeContainersChild} />
+            <div className={styles.shapeContainersChild} />
+            <div className={styles.shapeContainersChild} />
+          </div>
+          <div className={styles.shapeContainers}>
+            <div className={styles.shapeContainersChild} />
+            <div className={styles.shapeContainersChild} />
+            <div className={styles.shapeContainersChild} />
+            <div className={styles.shapeContainersChild} />
+          </div>
+        </div>
+        <Image
+          className={styles.patternItem}
+          width={351.4}
+          height={324.6}
+          sizes="100vw"
+          alt=""
+          src="/frame-62-1@2x.png"
+        />
+        <div className={styles.wrapperVector13}>
+          <Image
+            className={styles.wrapperVector13Child}
+            width={355.2}
+            height={355.2}
+            sizes="100vw"
+            alt=""
+            src="/vector-13.svg"
+          />
+        </div>
+        <Image
+          className={styles.patternInner}
+          width={603}
+          height={603}
+          sizes="100vw"
+          alt=""
+          src="/vector-15.svg"
+        />
+        <Image
+          className={styles.vectorIcon}
+          width={603}
+          height={603}
+          sizes="100vw"
+          alt=""
+          src="/vector-16.svg"
+        />
+        <div className={styles.patternChild1} />
+        <div className={styles.wrapperCircles}>
+          <Image
+            className={styles.circlesIcon}
+            width={438.8}
+            height={438.8}
+            sizes="100vw"
+            alt=""
+            src="/circles.svg"
+          />
+        </div>
+        <Image
+          className={styles.patternChild2}
+          width={257}
+          height={257}
+          sizes="100vw"
+          alt=""
+          src="/vector-19.svg"
+        />
+        <div className={styles.frameParent}>
+          <div className={styles.frameGroup}>
+            <div className={styles.overlayElementsWrapper}>
+              <div className={styles.overlayElements}>
+                <div className={styles.wrapperVector17}>
+                  <Image
+                    className={styles.wrapperVector17Child}
+                    width={71.5}
+                    height={71.5}
+                    sizes="100vw"
+                    alt=""
+                    src="/vector-17.svg"
+                  />
+                </div>
+                <div className={styles.wrapperVector17Wrapper}>
+                  <div className={styles.wrapperVector171}>
+                    <Image
+                      className={styles.wrapperVector17Item}
+                      width={241}
+                      height={241}
+                      sizes="100vw"
+                      alt=""
+                      src="/vector-17-1.svg"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div className={styles.wrapperVector18Wrapper}>
+              <div className={styles.wrapperVector18}>
+                <Image
+                  className={styles.wrapperVector18Child}
+                  width={432}
+                  height={381.5}
+                  sizes="100vw"
+                  alt=""
+                  src="/vector-18.svg"
+                />
+              </div>
+            </div>
+            <div className={styles.wrapperVector20}>
+              <Image
+                className={styles.wrapperVector20Child}
+                width={312}
+                height={312}
+                sizes="100vw"
+                alt=""
+                src="/vector-20.svg"
+              />
+            </div>
+          </div>
+          <div className={styles.wrapperVector14Wrapper}>
+            <div className={styles.wrapperVector14}>
+              <Image
+                className={styles.wrapperVector14Child}
+                loading="lazy"
+                width={534.7}
+                height={401}
+                sizes="100vw"
+                alt=""
+                src="/vector-14.svg"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Arkaplan;

--- a/components/destek-modules/frame-component.module.css
+++ b/components/destek-modules/frame-component.module.css
@@ -1,0 +1,73 @@
+.okIcon {
+  height: 0.831rem;
+  width: 1.106rem;
+  position: relative;
+  object-fit: contain;
+}
+.ebtexiKefeteGeri {
+  margin: 0;
+  position: relative;
+  font-size: inherit;
+  font-weight: 600;
+  font-family: inherit;
+}
+.backButton {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  gap: var(--gap-10);
+}
+.modllerimiz {
+  margin: 0;
+  position: relative;
+  font-size: inherit;
+  font-weight: 600;
+  font-family: inherit;
+}
+.modllerimizWrapper {
+  position: absolute;
+  top: 0.625rem;
+  left: 45.75rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+.arkaplanParent {
+  align-self: stretch;
+  height: 4.563rem;
+  position: relative;
+  border-radius: var(--br-10);
+  background-color: var(--color-white);
+  overflow: hidden;
+  flex-shrink: 0;
+  text-align: center;
+  font-size: var(--font-size-36);
+  color: var(--color-white);
+}
+.backButtonParent {
+  align-self: stretch;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+  gap: var(--gap-20);
+  text-align: left;
+  font-size: var(--font-size-22);
+  color: var(--color-mediumslateblue-200);
+  font-family: var(--font-poppins);
+}
+@media screen and (max-width: 900px) {
+  .modllerimiz {
+    font-size: 1.813rem;
+  }
+}
+@media screen and (max-width: 450px) {
+  .ebtexiKefeteGeri {
+    font-size: var(--font-size-18);
+  }
+  .modllerimiz {
+    font-size: var(--font-size-22);
+  }
+}

--- a/components/destek-modules/frame-component.tsx
+++ b/components/destek-modules/frame-component.tsx
@@ -1,0 +1,36 @@
+import type { NextPage } from "next";
+import Image from "next/image";
+import Arkaplan from "./arkaplan";
+import styles from "./frame-component.module.css";
+
+export type FrameComponentType = {
+  className?: string;
+  onBack?: () => void;
+};
+
+const FrameComponent: NextPage<FrameComponentType> = ({ className = "", onBack }) => {
+  return (
+    <section className={[styles.backButtonParent, className].join(" ")}>
+      <div className={styles.backButton} onClick={onBack}>
+        <Image
+          className={styles.okIcon}
+          loading="lazy"
+          width={17.7}
+          height={13.3}
+          sizes="100vw"
+          alt=""
+          src="/ok@2x.png"
+        />
+        <h3 className={styles.ebtexiKefeteGeri}>EBTEX’i Keşfet’e geri dön</h3>
+      </div>
+      <div className={styles.arkaplanParent}>
+        <Arkaplan />
+        <div className={styles.modllerimizWrapper}>
+          <h1 className={styles.modllerimiz}>Modüllerimiz</h1>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default FrameComponent;

--- a/components/destek-modules/header.module.css
+++ b/components/destek-modules/header.module.css
@@ -1,0 +1,88 @@
+.headerebtexMaviLogoIcon {
+  height: 2rem;
+  width: 2rem;
+  position: relative;
+}
+.ebtexBeyazTextIcon {
+  height: 1.25rem;
+  width: 5.625rem;
+  position: relative;
+}
+.logo,
+.logoWrapper {
+  display: flex;
+  justify-content: flex-start;
+}
+.logo {
+  flex-direction: row;
+  align-items: center;
+  gap: var(--gap-5);
+}
+.logoWrapper {
+  width: 15.875rem;
+  flex-direction: column;
+  align-items: flex-start;
+  padding: var(--padding-5) 0 0;
+  box-sizing: border-box;
+}
+.anasayfa {
+  position: relative;
+  font-weight: 600;
+}
+.navigationLinks {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  gap: var(--gap-15);
+}
+.navigationLinksWrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+  padding: 0.562rem 0 0;
+  box-sizing: border-box;
+  max-width: 100%;
+}
+.header,
+.secondaryNav {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  gap: var(--gap-10);
+}
+.header {
+  align-self: stretch;
+  box-shadow: 0 4px 4px rgba(0, 0, 0, 0.25);
+  background-color: var(--color-white);
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: var(--padding-19) 4.687rem;
+  box-sizing: border-box;
+  gap: var(--gap-20);
+  top: 0;
+  z-index: 99;
+  position: sticky;
+  max-width: 100%;
+  text-align: left;
+  font-size: var(--font-size-16);
+  color: var(--color-darkslategray);
+  font-family: var(--font-poppins);
+}
+@media screen and (max-width: 1300px) {
+  .navigationLinks {
+    display: none;
+  }
+  .header {
+    padding-left: 2.313rem;
+    padding-right: 2.313rem;
+    box-sizing: border-box;
+  }
+}
+@media screen and (max-width: 900px) {
+  .secondaryNav {
+    display: none;
+  }
+}

--- a/components/destek-modules/header.tsx
+++ b/components/destek-modules/header.tsx
@@ -1,0 +1,54 @@
+import type { NextPage } from "next";
+import Image from "next/image";
+import SecondaryNavButton from "./secondary-nav-button";
+import styles from "./header.module.css";
+
+export type HeaderType = {
+  className?: string;
+};
+
+const Header: NextPage<HeaderType> = ({ className = "" }) => {
+  return (
+    <header className={[styles.header, className].join(" ")}>
+      <div className={styles.logoWrapper}>
+        <div className={styles.logo}>
+          <Image
+            className={styles.headerebtexMaviLogoIcon}
+            loading="lazy"
+            width={32}
+            height={32}
+            sizes="100vw"
+            alt=""
+            src="/headerebtexmavilogo.svg"
+          />
+          <Image
+            className={styles.ebtexBeyazTextIcon}
+            loading="lazy"
+            width={90}
+            height={20}
+            sizes="100vw"
+            alt=""
+            src="/ebtexbeyaztext.svg"
+          />
+        </div>
+      </div>
+      <div className={styles.navigationLinksWrapper}>
+        <div className={styles.navigationLinks}>
+          <div className={styles.anasayfa}>Anasayfa</div>
+          <div className={styles.anasayfa}>Kurumsal</div>
+          <div className={styles.anasayfa}>Çözümler</div>
+          <div className={styles.anasayfa}>Ücretlendirme</div>
+          <div className={styles.anasayfa}>Referanslarımız</div>
+          <div className={styles.anasayfa}>SSS</div>
+          <div className={styles.anasayfa}>Bize Ulaşın</div>
+        </div>
+      </div>
+      <div className={styles.secondaryNav}>
+        <SecondaryNavButton property1="default" tEXT="Giriş" />
+        <SecondaryNavButton property1="default" tEXT="Demo" />
+      </div>
+    </header>
+  );
+};
+
+export default Header;

--- a/components/destek-modules/primary-nav-button.module.css
+++ b/components/destek-modules/primary-nav-button.module.css
@@ -1,0 +1,26 @@
+.text {
+  position: relative;
+  font-weight: 600;
+}
+.root {
+  align-self: stretch;
+  height: 2.625rem;
+  border-radius: var(--br-5);
+  background-color: var(--color-white);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 0 var(--padding-10);
+  box-sizing: border-box;
+  text-align: center;
+  font-size: var(--font-size-15);
+  color: var(--color-lightslategray);
+  font-family: var(--font-poppins);
+}
+.root[data-property1="click"] {
+  background-color: var(--color-mediumslateblue-400);
+}
+.root[data-property1="click"] .text {
+  color: var(--color-mediumslateblue-200);
+}

--- a/components/destek-modules/primary-nav-button.tsx
+++ b/components/destek-modules/primary-nav-button.tsx
@@ -1,0 +1,43 @@
+"use client";
+import type { NextPage } from "next";
+import { useMemo, type CSSProperties } from "react";
+import styles from "./primary-nav-button.module.css";
+
+export type PrimaryNavButtonType = {
+  className?: string;
+  tEXT?: string;
+
+  /** Variant props */
+  property1?: "default" | "click";
+
+  /** Style props */
+  primaryNavButtonAlignSelf?: CSSProperties["alignSelf"];
+  primaryNavButtonWidth?: CSSProperties["width"];
+};
+
+const PrimaryNavButton: NextPage<PrimaryNavButtonType> = ({
+  className = "",
+  property1 = "default",
+  primaryNavButtonAlignSelf,
+  primaryNavButtonWidth,
+  tEXT,
+}) => {
+  const primaryNavButtonStyle: CSSProperties = useMemo(() => {
+    return {
+      alignSelf: primaryNavButtonAlignSelf,
+      width: primaryNavButtonWidth,
+    };
+  }, [primaryNavButtonAlignSelf, primaryNavButtonWidth]);
+
+  return (
+    <div
+      className={[styles.root, className].join(" ")}
+      data-property1={property1}
+      style={primaryNavButtonStyle}
+    >
+      <div className={styles.text}>{tEXT}</div>
+    </div>
+  );
+};
+
+export default PrimaryNavButton;

--- a/components/destek-modules/secondary-nav-button.module.css
+++ b/components/destek-modules/secondary-nav-button.module.css
@@ -1,0 +1,22 @@
+.text {
+  position: relative;
+  font-size: 0.813rem;
+  font-weight: 600;
+  font-family: var(--font-poppins);
+  color: var(--color-darkorchid-100);
+  text-align: center;
+}
+.secondaryNavButton {
+  cursor: pointer;
+  border: 0;
+  padding: 0 var(--padding-40);
+  background-color: var(--color-darkorchid-200);
+  height: 2.625rem;
+  width: 7.625rem;
+  border-radius: var(--br-5);
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+}

--- a/components/destek-modules/secondary-nav-button.tsx
+++ b/components/destek-modules/secondary-nav-button.tsx
@@ -1,0 +1,27 @@
+import type { NextPage } from "next";
+import styles from "./secondary-nav-button.module.css";
+
+export type SecondaryNavButtonType = {
+  className?: string;
+  tEXT?: string;
+
+  /** Variant props */
+  property1?: string;
+};
+
+const SecondaryNavButton: NextPage<SecondaryNavButtonType> = ({
+  className = "",
+  property1 = "default",
+  tEXT,
+}) => {
+  return (
+    <button
+      className={[styles.secondaryNavButton, className].join(" ")}
+      data-property1={property1}
+    >
+      <div className={styles.text}>{tEXT}</div>
+    </button>
+  );
+};
+
+export default SecondaryNavButton;


### PR DESCRIPTION
## Summary
- move Destek Merkezi page to components and split into reusable parts
- add a `destek-modules` component folder
- expose a `DestekMerkezi` component that can be opened from the main page
- show Destek Merkez on `website-design.tsx` when selected

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845ac9c8714832c872177bf1e61cd0f