### PR TITLE
Add iframe display for modules

### DIFF
--- a/app/website-design.tsx
+++ b/app/website-design.tsx
@@ -12,13 +12,8 @@ import Root3 from "./root3/root3";
 import Referanslarmz from "../components/referanslarmz";
 import MesajGnder from "../components/mesaj-gnder";
 import Footer from "../components/footer";
-import DestekMerkezi from "../components/DestekMerkezi";
-import { useState } from "react";
+
 const WebsiteDesign: NextPage = () => {
-  const [showDestek, setShowDestek] = useState(false);
-  if (showDestek) {
-    return <DestekMerkezi onBack={() => setShowDestek(false)} />;
-  }
   return (
     <>
       <GrmeNavbarOn />
@@ -28,15 +23,13 @@ const WebsiteDesign: NextPage = () => {
       </div>
       <Root />
       <Website />
-      <Website1 onModuleClick={() => setShowDestek(true)} />
+      <Website1 />
       <Root1 />
       <Frame2461 />
       <Root2 />
       <Root3 />
       <Referanslarmz />
       <MesajGnder />
-
-      {showDestek && <DestekMerkezi />}
 
       <Footer />
     </>

--- a/components/website1.tsx
+++ b/components/website1.tsx
@@ -1,12 +1,20 @@
 import type { NextPage } from "next";
+import { useState } from "react";
 import FrameComponent21 from "./frame-component2";
 
 export type Website1Type = {
   className?: string;
-  onModuleClick?: () => void;
 };
 
-const Website1: NextPage<Website1Type> = ({ className = "", onModuleClick }) => {
+const Website1: NextPage<Website1Type> = ({ className = "" }) => {
+  const [iframeOpen, setIframeOpen] = useState(false);
+
+  const handleModuleClick = () => {
+    setIframeOpen(true);
+  };
+
+  const closeIframe = () => setIframeOpen(false);
+
   return (
     <div
       className={`w-full max-w-[120rem] mx-auto h-[53.813rem] bg-[#f9fafc] overflow-hidden flex flex-col items-center justify-start !pt-[4.375rem] !pb-[4.375rem] !pl-5 !pr-5 box-border gap-[3.125rem] leading-[normal] tracking-[normal] text-center text-base text-[#5c67f7] font-[Poppins] ${className}`}
@@ -42,7 +50,7 @@ const Website1: NextPage<Website1Type> = ({ className = "", onModuleClick }) => 
             yoklamaYnetim="Yoklama Yönetim"
             group533="/group-53-3.svg"
             burslulukYnetim="Bursluluk Yönetim"
-            onModuleClick={onModuleClick}
+            onModuleClick={handleModuleClick}
           />
           <FrameComponent21
             className="mq450:flex-col"
@@ -54,7 +62,7 @@ const Website1: NextPage<Website1Type> = ({ className = "", onModuleClick }) => 
             yoklamaYnetim="Servis Ulaşım"
             group533="/group-53-7.svg"
             burslulukYnetim="Finans ve Muhasebe"
-            onModuleClick={onModuleClick}
+            onModuleClick={handleModuleClick}
           />
           <FrameComponent21
             className="mq450:flex-col"
@@ -66,7 +74,7 @@ const Website1: NextPage<Website1Type> = ({ className = "", onModuleClick }) => 
             yoklamaYnetim="Etkinlik Yönetimi"
             group533="/group-53-11.svg"
             burslulukYnetim="Rehberlik Takip"
-            onModuleClick={onModuleClick}
+            onModuleClick={handleModuleClick}
           />
         </div>
         <div className="flex flex-row items-start justify-start !pt-0 !pb-0 !pl-[45.875rem] !pr-[45.875rem] mq450:!pl-5 mq450:!pr-5 mq450:box-border">
@@ -75,6 +83,19 @@ const Website1: NextPage<Website1Type> = ({ className = "", onModuleClick }) => 
           </div>
         </div>
       </main>
+      {iframeOpen && (
+        <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center">
+          <div className="relative w-11/12 h-5/6 bg-white rounded-md overflow-hidden">
+            <button
+              className="absolute top-2 right-2 z-10 text-black bg-white rounded-full px-2"
+              onClick={closeIframe}
+            >
+              X
+            </button>
+            <iframe src="/destek_modules/app" className="w-full h-full border-0" />
+          </div>
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- update `Website1` to open modules in-page using an iframe
- simplify `website-design` page now that modules no longer trigger a page swap

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845b92dbbd0832ca8783926000afb03