### PR TITLE
Add slider logic to DASHBOARDS

### DIFF
--- a/components/d-a-s-h-b-o-a-r-d-s.tsx
+++ b/components/d-a-s-h-b-o-a-r-d-s.tsx
@@ -1,37 +1,97 @@
 import type { NextPage } from "next";
+import { useEffect, useRef } from "react";
+import styles from "./dashboard-slider.module.css";
 
 export type DASHBOARDSType = {
   className?: string;
 };
 
+const roles = ["Veli", "Servis Şoförü", "Öğrenci", "Rehberlik", "Öğretmen"];
+
 const DASHBOARDS: NextPage<DASHBOARDSType> = ({ className = "" }) => {
+  const sliderRef = useRef<HTMLUListElement>(null);
+
+  useEffect(() => {
+    const slider = sliderRef.current;
+    if (!slider) return;
+
+    let isDragging = false;
+    let startX = 0;
+    let scrollStart = 0;
+
+    const easeOut = (t: number) => 1 - Math.pow(1 - t, 3);
+
+    const animateScroll = (target: number) => {
+      const duration = 350;
+      const from = slider.scrollLeft;
+      const change = target - from;
+      const startTime = performance.now();
+
+      const step = (now: number) => {
+        const elapsed = now - startTime;
+        const progress = Math.min(elapsed / duration, 1);
+        slider.scrollLeft = from + change * easeOut(progress);
+        if (progress < 1) requestAnimationFrame(step);
+      };
+      requestAnimationFrame(step);
+    };
+
+    const snapToCard = () => {
+      const card = slider.querySelector(`.${styles.card}`) as HTMLElement | null;
+      if (!card) return;
+      const style = getComputedStyle(slider);
+      const gap = parseInt(style.gap) || 0;
+      const cardWidth = card.offsetWidth + gap;
+      const index = Math.round(slider.scrollLeft / cardWidth);
+      animateScroll(index * cardWidth);
+    };
+
+    const handlePointerDown = (e: PointerEvent) => {
+      isDragging = true;
+      slider.setPointerCapture(e.pointerId);
+      startX = e.clientX;
+      scrollStart = slider.scrollLeft;
+    };
+
+    const handlePointerMove = (e: PointerEvent) => {
+      if (!isDragging) return;
+      const dx = e.clientX - startX;
+      slider.scrollLeft = scrollStart - dx;
+    };
+
+    const endDrag = () => {
+      if (!isDragging) return;
+      isDragging = false;
+      snapToCard();
+    };
+
+    slider.addEventListener("pointerdown", handlePointerDown);
+    slider.addEventListener("pointermove", handlePointerMove);
+    slider.addEventListener("pointerup", endDrag);
+    slider.addEventListener("pointercancel", endDrag);
+    slider.addEventListener("pointerleave", endDrag);
+
+    return () => {
+      slider.removeEventListener("pointerdown", handlePointerDown);
+      slider.removeEventListener("pointermove", handlePointerMove);
+      slider.removeEventListener("pointerup", endDrag);
+      slider.removeEventListener("pointercancel", endDrag);
+      slider.removeEventListener("pointerleave", endDrag);
+    };
+  }, []);
+
   return (
     <section
       className={`w-[107rem] h-[19.263rem] flex flex-row items-start justify-start !pt-[1.188rem] !pb-[1.144rem] !pl-[13.563rem] !pr-[13.519rem] box-border relative z-[2] text-center text-[1.206rem] text-[#000] font-[Poppins] mq450:flex-col ${className}`}
     >
-      <section className="h-[14.213rem] w-full !!m-[0 important] absolute top-[2.5rem] right-[0rem] left-[0rem] flex flex-row items-center justify-between gap-0 z-[0] text-center text-[0.888rem] text-[#000] font-[Poppins] mq450:static mq450:flex-col mq450:items-center">
-        <div className="h-[14.213rem] w-[26.875rem] shadow-[0px_4px_4px_rgba(0,_0,_0,_0.25)] rounded-[0.138rem] bg-[#fff] flex flex-col items-center justify-center !pt-[0.344rem] !pb-[0.969rem] !pl-[0.344rem] !pr-[0.344rem] box-border gap-[0.969rem]">
-          <div className="self-stretch h-[10.581rem] relative hidden" />
-          <div className="relative font-medium">Veli</div>
-        </div>
-        <div className="w-[26.875rem] shadow-[0px_4px_4px_rgba(0,_0,_0,_0.25)] rounded-[0.138rem] bg-[#fff] flex flex-col items-center justify-center !pt-[0.344rem] !pb-[0.969rem] !pl-[0.344rem] !pr-[0.344rem] box-border gap-[0.969rem]">
-          <div className="self-stretch h-[10.588rem] relative hidden" />
-          <div className="relative font-medium">Servis Şoförü</div>
-        </div>
-      </section>
-      <section className="h-[16.931rem] w-[79.919rem] flex flex-row items-center justify-between gap-0 z-[1] text-center text-[1.056rem] text-[#000] font-[Poppins] mq450:flex-col mq450:items-center">
-        <div className="h-[16.931rem] w-[32.031rem] shadow-[0px_4px_4px_rgba(0,_0,_0,_0.25)] rounded-[0.163rem] bg-[#fff] flex flex-col items-center justify-center !pt-[0.413rem] !pb-[1.156rem] !pl-[0.413rem] !pr-[0.413rem] box-border gap-[1.156rem]">
-          <div className="self-stretch h-[12.619rem] relative hidden" />
-          <div className="relative font-medium">Öğrenci</div>
-        </div>
-        <div className="h-[16.931rem] w-[32.031rem] shadow-[0px_4px_4px_rgba(0,_0,_0,_0.25)] rounded-[0.163rem] bg-[#fff] flex flex-col items-center justify-center !pt-[0.413rem] !pb-[1.156rem] !pl-[0.413rem] !pr-[0.413rem] box-border gap-[1.156rem]">
-          <div className="self-stretch h-[12.619rem] relative hidden" />
-          <div className="relative font-medium">Rehberlik</div>
-        </div>
-      </section>
-      <div className="h-full w-[36.444rem] !!m-[0 important] absolute top-[0rem] bottom-[0rem] left-[35.25rem] shadow-[0px_4px_4px_rgba(0,_0,_0,_0.25)] rounded-[0.188rem] bg-[#fff] flex flex-col items-center justify-center !pt-[0.469rem] !pb-[1.319rem] !pl-[0.469rem] !pr-[0.469rem] box-border gap-[1.319rem] z-[2]">
-        <div className="self-stretch h-[14.356rem] relative hidden" />
-        <div className="relative font-medium">Öğretmen</div>
+      <div className={styles.sliderContainer}>
+        <ul className={styles.slider} ref={sliderRef}>
+          {roles.map((role) => (
+            <li key={role} className={styles.card}>
+              {role}
+            </li>
+          ))}
+        </ul>
       </div>
     </section>
   );

--- a/components/dashboard-slider.module.css
+++ b/components/dashboard-slider.module.css
@@ -1,0 +1,38 @@
+.sliderContainer {
+  width: 100%;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  scroll-padding: 0 50%;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+  display: flex;
+}
+.sliderContainer::-webkit-scrollbar {
+  display: none;
+}
+.slider {
+  display: flex;
+  gap: 1rem;
+  padding: 0 50%;
+}
+.card {
+  flex: 0 0 auto;
+  width: 20rem;
+  height: 13.75rem;
+  background-color: var(--color-white);
+  border-radius: var(--br-5);
+  box-shadow: 0 4px 4px rgba(0, 0, 0, 0.25);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 500;
+  scroll-snap-align: center;
+}
+@media (max-width: 768px) {
+  .slider {
+    padding: 0 5%;
+  }
+  .card {
+    width: 90%;
+  }
+}

--- a/slider-demo/index.html
+++ b/slider-demo/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Slider Demo</title>
+  <!-- Bağlı stil dosyası -->
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="slider-container">
+    <ul class="slider" id="slider">
+      <!-- Her rolde kullanılacak kartlar -->
+      <li class="card">Veli</li>
+      <li class="card">Servis Şoförü</li>
+      <li class="card">Öğrenci</li>
+      <li class="card">Rehberlik</li>
+      <li class="card">Öğretmen</li>
+    </ul>
+  </div>
+  <!-- Sürükleme ve snap işlemleri -->
+  <script src="slider.js"></script>
+</body>
+</html>

--- a/slider-demo/slider.js
+++ b/slider-demo/slider.js
@@ -1,0 +1,70 @@
+// Kaydırma işlemleri için liste elemanını seçiyoruz
+const slider = document.getElementById('slider');
+
+// Sürükleme sırasında kullanılacak değişkenler
+let isDragging = false;    // Kullanıcı basılı mı?
+let startX = 0;            // Başlangıç tıklama konumu
+let scrollStart = 0;       // Başlangıçta scrollLeft değeri
+
+// Easing fonksiyonu (ease-out)
+function easeOut(t) {
+  return 1 - Math.pow(1 - t, 3);
+}
+
+// Belirlenen hedefe 0.35s boyunca kaydır
+function animateScroll(target) {
+  const duration = 350;                      // ms cinsinden
+  const from = slider.scrollLeft;
+  const change = target - from;
+  const startTime = performance.now();
+
+  function step(now) {
+    const elapsed = now - startTime;
+    const progress = Math.min(elapsed / duration, 1);
+    slider.scrollLeft = from + change * easeOut(progress);
+    if (progress < 1) {
+      requestAnimationFrame(step);
+    }
+  }
+  requestAnimationFrame(step);
+}
+
+// En yakın kartın konumunu hesapla ve oraya kaydır
+function snapToCard() {
+  const card = slider.querySelector('.card');
+  if (!card) return;
+  const cardStyle = getComputedStyle(slider);
+  const gap = parseInt(cardStyle.gap) || 0;
+  const cardWidth = card.offsetWidth + gap;
+  const index = Math.round(slider.scrollLeft / cardWidth);
+  const target = index * cardWidth;
+  animateScroll(target);
+}
+
+// Pointer down => sürükleme başlasın
+slider.addEventListener('pointerdown', (e) => {
+  isDragging = true;
+  slider.setPointerCapture(e.pointerId);
+  startX = e.clientX;
+  scrollStart = slider.scrollLeft;
+});
+
+// Pointer hareket ederse scrollLeft'i güncelle
+slider.addEventListener('pointermove', (e) => {
+  if (!isDragging) return;
+  const dx = e.clientX - startX;
+  slider.scrollLeft = scrollStart - dx;
+});
+
+// Bırakıldığında sürükleme bitsin ve en yakın karta hizala
+function endDrag() {
+  if (!isDragging) return;
+  isDragging = false;
+  snapToCard();
+}
+
+// Tüm bitiş durumlarında hizalamayı tetikle
+slider.addEventListener('pointerup', endDrag);
+slider.addEventListener('pointercancel', endDrag);
+slider.addEventListener('pointerleave', endDrag);
+

--- a/slider-demo/style.css
+++ b/slider-demo/style.css
@@ -1,0 +1,62 @@
+/* Temel sıfırlama */
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: #ececec;
+  font-family: Arial, Helvetica, sans-serif;
+}
+
+/* Kaydırıcı kapsayıcısı */
+.slider-container {
+  width: 100%;
+  overflow-x: auto;             /* Yatay kaydırma */
+  scroll-snap-type: x mandatory;/* Snap davranışı */
+  scroll-padding: 0 50%;        /* İlk/son elemanların ortalanabilmesi için */
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;        /* Firefox'ta scrollbar gizleme */
+}
+.slider-container::-webkit-scrollbar {
+  display: none;                /* Diğer tarayıcılarda scrollbar gizleme */
+}
+
+/* Kartları tutan liste */
+.slider {
+  display: flex;
+  gap: 1rem;                    /* Kartlar arası boşluk */
+  padding: 0 50%;               /* Merkezde gösterme için boşluk */
+}
+
+/* Her bir kartın görünümü */
+.card {
+  flex: 0 0 auto;               /* Genişlik sabit, esneme yok */
+  width: 320px;                 /* Kart genişliği */
+  height: 220px;                /* Kart yüksekliği */
+  background: #fff;             /* Beyaz zemin */
+  border-radius: 8px;           /* Köşeleri yuvarla */
+  box-shadow: 0 4px 4px rgba(0, 0, 0, 0.25); /* Hafif gölge */
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 1.25rem;
+  font-weight: 500;
+  scroll-snap-align: center;    /* Kart ortalanarak hizalansın */
+  transition: transform 0.35s ease-out;
+}
+
+/* Mobil görünüm: tek kart */
+@media (max-width: 768px) {
+  .slider {
+    padding: 0 5%;             /* Dar ekranda daha az boşluk */
+  }
+  .card {
+    width: 90%;                /* Kart genişliğini %90 yap */
+  }
+}


### PR DESCRIPTION
## Summary
- create a CSS module for slider styles
- replace the hard-coded card layout with a draggable slider in `DASHBOARDS`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849324065f0832ca3df136ca56a89c7