### PR TITLE
Implement scrolling links and interactive forms

### DIFF
--- a/app/website-design.tsx
+++ b/app/website-design.tsx
@@ -17,19 +17,33 @@ const WebsiteDesign: NextPage = () => {
   return (
     <>
       <GrmeNavbarOn />
-      <div className="w-full relative flex flex-row items-start justify-start leading-[normal] tracking-[normal]">
+      <section id="anasayfa" className="w-full relative flex flex-row items-start justify-start leading-[normal] tracking-[normal]">
         <Component1 />
 
-      </div>
-      <Root />
-      <Website />
-      <Website1 />
-      <Root1 />
-      <Frame2461 />
-      <Root2 />
-      <Root3 />
-      <Referanslarmz />
-      <MesajGnder />
+      </section>
+      <section id="kurumsal">
+        <Root />
+      </section>
+      <section id="cozumler">
+        <Website />
+        <Website1 />
+        <Root1 />
+      </section>
+      <section id="kullanici-merkezi">
+        <Frame2461 />
+      </section>
+      <section id="ucretlendirme">
+        <Root2 />
+      </section>
+      <section id="sss">
+        <Root3 />
+      </section>
+      <section id="referanslar">
+        <Referanslarmz />
+      </section>
+      <section id="iletisim">
+        <MesajGnder />
+      </section>
 
       <Footer />
     </>

--- a/components/frame-component1.tsx
+++ b/components/frame-component1.tsx
@@ -1,10 +1,11 @@
-import type { NextPage } from "next";
+"use client";
+import type { FC } from "react";
 
 export type FrameComponent1Type = {
   className?: string;
 };
 
-const FrameComponent1: NextPage<FrameComponent1Type> = ({ className = "" }) => {
+const FrameComponent1: FC<FrameComponent1Type> = ({ className = "" }) => {
   return (
     <div
       className={`h-[24.125rem] shadow-[0px_4px_4px_rgba(0,_0,_0,_0.25)] rounded-[1.875rem] bg-[#fff] overflow-hidden flex flex-col items-start justify-start !pt-[1.688rem] !pb-[1.688rem] !pl-[1.813rem] !pr-[1.813rem] box-border gap-[1.563rem] text-left text-[2rem] text-[#27313c] font-[Poppins] ${className}`}
@@ -31,9 +32,9 @@ const FrameComponent1: NextPage<FrameComponent1Type> = ({ className = "" }) => {
         </div>
       </div>
       <div className="w-[30.938rem] h-[2.375rem] flex flex-col items-end justify-center text-[0.938rem] text-[#fff]">
-        <div className="rounded-md bg-[#5c67f7] flex flex-row items-center justify-center !pt-[0.469rem] !pb-[0.469rem] !pl-[0.938rem] !pr-[0.938rem]">
+        <button className="rounded-md bg-[#5c67f7] flex flex-row items-center justify-center !pt-[0.469rem] !pb-[0.469rem] !pl-[0.938rem] !pr-[0.938rem]">
           <div className="relative font-semibold">Satın Al</div>
-        </div>
+        </button>
       </div>
     </div>
   );

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -2,6 +2,7 @@
 import type { NextPage } from "next";
 import Image from "next/image";
 import { useState } from "react";
+import MesajGnder from "./mesaj-gnder";
 import SecondaryNavButton from "./secondary-nav-button";
 
 export type HeaderType = {
@@ -10,7 +11,9 @@ export type HeaderType = {
 
 const Header: NextPage<HeaderType> = ({ className = "" }) => {
   const [open, setOpen] = useState(false);
+  const [demoOpen, setDemoOpen] = useState(false);
   return (
+    <>
     <div
       className={`h-20 w-full shadow-[0px_4px_4px_rgba(0,_0,_0,_0.25)] bg-[#fff] flex flex-row items-center justify-between !pt-[19px] !pb-[19px] !pl-[75px] !pr-[75px] box-border gap-8 text-left text-base text-[#27313c] font-[Poppins] ${className}`}
     >
@@ -35,17 +38,21 @@ const Header: NextPage<HeaderType> = ({ className = "" }) => {
         />
       </div>
       <div className="flex flex-row items-center justify-center gap-[15px] mq450:hidden">
-        <div className="relative font-semibold">Anasayfa</div>
-        <div className="relative font-semibold">Kurumsal</div>
-        <div className="relative font-semibold">Çözümler</div>
-        <div className="relative font-semibold">Ücretlendirme</div>
-        <div className="relative font-semibold">Referanslarımız</div>
-        <div className="relative font-semibold">SSS</div>
-        <div className="relative font-semibold">Bize Ulaşın</div>
+        <a href="#anasayfa" className="relative font-semibold">Anasayfa</a>
+        <a href="#kurumsal" className="relative font-semibold">Kurumsal</a>
+        <a href="#cozumler" className="relative font-semibold">Çözümler</a>
+        <a href="#ucretlendirme" className="relative font-semibold">Ücretlendirme</a>
+        <a href="#referanslar" className="relative font-semibold">Referanslarımız</a>
+        <a href="#sss" className="relative font-semibold">SSS</a>
+        <a href="#iletisim" className="relative font-semibold">Bize Ulaşın</a>
       </div>
       <div className="flex flex-row items-center justify-center gap-2.5 text-center text-[13px] text-[#9e5cf7] mq450:hidden">
-        <SecondaryNavButton property1="default" tEXT="Giriş" />
-        <SecondaryNavButton property1="default" tEXT="Demo" />
+        <a href="https://panel.ebtex.com.tr" target="_blank" rel="noopener noreferrer">
+          <SecondaryNavButton property1="default" tEXT="Giriş" />
+        </a>
+        <button onClick={() => setDemoOpen(true)}>
+          <SecondaryNavButton property1="default" tEXT="Demo" />
+        </button>
       </div>
       <button className="hidden mq450:block" onClick={() => setOpen(!open)}>
         <Image width={24} height={24} alt="menu" src="/hamburger.svg" />
@@ -55,20 +62,35 @@ const Header: NextPage<HeaderType> = ({ className = "" }) => {
           <button className="self-end mb-2" onClick={() => setOpen(false)}>
             ✕
           </button>
-          <a className="font-semibold">Anasayfa</a>
-          <a className="font-semibold">Kurumsal</a>
-          <a className="font-semibold">Çözümler</a>
-          <a className="font-semibold">Ücretlendirme</a>
-          <a className="font-semibold">Referanslarımız</a>
-          <a className="font-semibold">SSS</a>
-          <a className="font-semibold">Bize Ulaşın</a>
+          <a href="#anasayfa" className="font-semibold" onClick={() => setOpen(false)}>Anasayfa</a>
+          <a href="#kurumsal" className="font-semibold" onClick={() => setOpen(false)}>Kurumsal</a>
+          <a href="#cozumler" className="font-semibold" onClick={() => setOpen(false)}>Çözümler</a>
+          <a href="#ucretlendirme" className="font-semibold" onClick={() => setOpen(false)}>Ücretlendirme</a>
+          <a href="#referanslar" className="font-semibold" onClick={() => setOpen(false)}>Referanslarımız</a>
+          <a href="#sss" className="font-semibold" onClick={() => setOpen(false)}>SSS</a>
+          <a href="#iletisim" className="font-semibold" onClick={() => setOpen(false)}>Bize Ulaşın</a>
           <div className="flex flex-row items-center justify-start gap-2.5 text-[13px] text-[#9e5cf7]">
-            <SecondaryNavButton property1="default" tEXT="Giriş" />
-            <SecondaryNavButton property1="default" tEXT="Demo" />
+            <a href="https://panel.ebtex.com.tr" target="_blank" rel="noopener noreferrer">
+              <SecondaryNavButton property1="default" tEXT="Giriş" />
+            </a>
+            <button onClick={() => { setDemoOpen(true); setOpen(false); }}>
+              <SecondaryNavButton property1="default" tEXT="Demo" />
+            </button>
           </div>
         </div>
       )}
     </div>
+    {demoOpen && (
+      <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+        <div className="bg-white p-4 max-w-full overflow-auto">
+          <button className="self-end mb-2" onClick={() => setDemoOpen(false)}>
+            ✕
+          </button>
+          <MesajGnder />
+        </div>
+      </div>
+    )}
+    </>
   );
 };
 

--- a/components/mesaj-gnder.tsx
+++ b/components/mesaj-gnder.tsx
@@ -1,4 +1,5 @@
-import type { NextPage } from "next";
+"use client";
+import type { FC } from "react";
 import S from "./s";
 import Bilgiler from "./bilgiler";
 
@@ -6,9 +7,9 @@ export type MesajGnderType = {
   className?: string;
 };
 
-const MesajGnder: NextPage<MesajGnderType> = ({ className = "" }) => {
+const MesajGnder: FC<MesajGnderType> = ({ className = "" }) => {
   return (
-    <div
+    <form
       className={`w-[60.25rem] shadow-[0px_4px_4px_3px_rgba(0,_0,_0,_0.25)] rounded-[0.625rem] bg-[#fff] border-[#e6eff3] border-solid border-[0.063rem] box-border max-w-full overflow-hidden flex flex-row items-center justify-center !pt-[1.125rem] !pb-[1.125rem] !pl-[2.438rem] !pr-[2.438rem] gap-5 leading-[normal] tracking-[normal] text-center text-2xl text-[#27313c] font-[Poppins] mx-auto ${className}`}
     >
       <Bilgiler />
@@ -22,19 +23,20 @@ const MesajGnder: NextPage<MesajGnderType> = ({ className = "" }) => {
           <S adSoyad="Telefon" adSoyadnzGiriniz="Telefon Numaranızı Giriniz" />
           <S adSoyad="Kurum Adı" adSoyadnzGiriniz="Kurum Adını Giriniz" />
           <div className="self-stretch flex flex-col items-start justify-center gap-[0.188rem]">
-            <div className="self-stretch relative font-medium">Mesaj</div>
-            <div className="self-stretch h-20 rounded-[0.625rem] bg-[#f8f9f9] border-[#e6eff3] border-solid border-[0.063rem] box-border flex flex-col items-start justify-start !p-2.5 text-right text-[0.813rem] text-[#686f77]">
-              <div className="relative">Mesajınızı Giriniz</div>
-            </div>
+            <label className="self-stretch relative font-medium">Mesaj</label>
+            <textarea
+              className="self-stretch h-20 rounded-[0.625rem] bg-[#f8f9f9] border-[#e6eff3] border-solid border-[0.063rem] box-border p-2.5 text-[0.813rem] text-[#686f77]"
+              placeholder="Mesajınızı Giriniz"
+            />
           </div>
         </section>
         <div className="self-stretch flex flex-col items-end justify-center text-left text-[0.938rem] text-[#fff]">
-          <div className="rounded-md bg-[#5c67f7] flex flex-row items-center justify-center !pt-[0.469rem] !pb-[0.469rem] !pl-[0.938rem] !pr-[0.938rem]">
+          <button type="submit" className="rounded-md bg-[#5c67f7] flex flex-row items-center justify-center !pt-[0.469rem] !pb-[0.469rem] !pl-[0.938rem] !pr-[0.938rem]">
             <div className="relative font-semibold">Mesajı Gönder</div>
-          </div>
+          </button>
         </div>
       </div>
-    </div>
+    </form>
   );
 };
 

--- a/components/root2.tsx
+++ b/components/root2.tsx
@@ -1,4 +1,5 @@
-import type { NextPage } from "next";
+"use client";
+import type { FC } from "react";
 import Image from "next/image";
 import Component11 from "./component11";
 import FrameComponent1 from "./frame-component1";
@@ -10,7 +11,7 @@ export type Root2Type = {
   property1?: 10;
 };
 
-const Root2: NextPage<Root2Type> = ({ className = "", property1 = 10 }) => {
+const Root2: FC<Root2Type> = ({ className = "", property1 = 10 }) => {
   return (
     <div
       className={`w-full max-w-[120rem] mx-auto h-[43.688rem] bg-[#e9ecfb] overflow-hidden flex flex-col items-end justify-start !pt-[4.375rem] !pb-[4.375rem] !pl-[22.938rem] !pr-[22.938rem] box-border gap-10 text-center text-base text-[#5c67f7] font-[Poppins] ${className}`}
@@ -62,9 +63,11 @@ const Root2: NextPage<Root2Type> = ({ className = "", property1 = 10 }) => {
                       Anaokulu Öğrenci Sayısı
                     </div>
                   </div>
-                  <div className="h-10 rounded-[0.625rem] bg-[#f8f9f9] flex flex-col items-start justify-center !pt-0 !pb-0 !pl-2.5 !pr-2.5 box-border text-[#686f77]">
-                    <div className="relative">Öğrenci Sayısı Giriniz</div>
-                  </div>
+                  <input
+                    type="number"
+                    placeholder="Öğrenci Sayısı Giriniz"
+                    className="h-10 rounded-[0.625rem] bg-[#f8f9f9] flex flex-col items-start justify-center !pl-2.5 !pr-2.5 box-border text-[#686f77]"
+                  />
                 </div>
                 <div className="self-stretch flex flex-row items-center justify-between gap-0 text-left">
                   <div className="w-[15.563rem] flex flex-row items-center justify-start gap-[0.563rem]">
@@ -81,9 +84,11 @@ const Root2: NextPage<Root2Type> = ({ className = "", property1 = 10 }) => {
                       İlkokul Öğrenci Sayısı
                     </div>
                   </div>
-                  <div className="h-10 rounded-[0.625rem] bg-[#f8f9f9] flex flex-col items-start justify-center !pt-0 !pb-0 !pl-2.5 !pr-2.5 box-border text-right text-[#686f77]">
-                    <div className="relative">Öğrenci Sayısı Giriniz</div>
-                  </div>
+                  <input
+                    type="number"
+                    placeholder="Öğrenci Sayısı Giriniz"
+                    className="h-10 rounded-[0.625rem] bg-[#f8f9f9] flex flex-col items-start justify-center !pl-2.5 !pr-2.5 box-border text-right text-[#686f77]"
+                  />
                 </div>
                 <div className="self-stretch flex flex-row items-center justify-between gap-0">
                   <div className="w-[15.563rem] flex flex-row items-center justify-start gap-[0.563rem]">
@@ -100,9 +105,11 @@ const Root2: NextPage<Root2Type> = ({ className = "", property1 = 10 }) => {
                       Ortaokul Öğrenci Sayısı
                     </div>
                   </div>
-                  <div className="h-10 w-[9.813rem] rounded-[0.625rem] bg-[#f8f9f9] flex flex-col items-start justify-center !pt-0 !pb-0 !pl-2.5 !pr-2.5 box-border text-[0.938rem] text-[#27313c]">
-                    <div className="relative">100</div>
-                  </div>
+                  <input
+                    type="number"
+                    defaultValue={100}
+                    className="h-10 w-[9.813rem] rounded-[0.625rem] bg-[#f8f9f9] flex flex-col items-start justify-center !pl-2.5 !pr-2.5 box-border text-[0.938rem] text-[#27313c]"
+                  />
                 </div>
                 <div className="self-stretch flex flex-row items-center justify-between gap-0 text-left">
                   <div className="w-[15.563rem] flex flex-row items-center justify-start gap-[0.563rem]">
@@ -119,9 +126,11 @@ const Root2: NextPage<Root2Type> = ({ className = "", property1 = 10 }) => {
                       Lise Öğrenci Sayısı
                     </div>
                   </div>
-                  <div className="h-10 w-[9.813rem] rounded-[0.625rem] bg-[#f8f9f9] flex flex-col items-start justify-center !pt-0 !pb-0 !pl-2.5 !pr-2.5 box-border text-right text-[0.938rem] text-[#27313c]">
-                    <div className="relative">250</div>
-                  </div>
+                  <input
+                    type="number"
+                    defaultValue={250}
+                    className="h-10 w-[9.813rem] rounded-[0.625rem] bg-[#f8f9f9] flex flex-col items-start justify-center !pl-2.5 !pr-2.5 box-border text-right text-[0.938rem] text-[#27313c]"
+                  />
                 </div>
               </div>
               <div className="self-stretch" />

--- a/components/s.tsx
+++ b/components/s.tsx
@@ -1,4 +1,5 @@
-import type { NextPage } from "next";
+"use client";
+import type { FC } from "react";
 
 export type SType = {
   className?: string;
@@ -6,17 +7,19 @@ export type SType = {
   adSoyadnzGiriniz?: string;
 };
 
-const S: NextPage<SType> = ({ className = "", adSoyad, adSoyadnzGiriniz }) => {
+const S: FC<SType> = ({ className = "", adSoyad, adSoyadnzGiriniz }) => {
   return (
     <div
       className={`self-stretch flex flex-col items-start justify-center gap-[0.188rem] text-right text-[0.813rem] text-[#686f77] font-[Poppins] ${className}`}
     >
-      <header className="self-stretch relative text-[0.938rem] font-medium font-[Poppins] text-[#27313c] text-left">
+      <label className="self-stretch relative text-[0.938rem] font-medium font-[Poppins] text-[#27313c] text-left">
         {adSoyad}
-      </header>
-      <div className="self-stretch h-10 rounded-[0.625rem] bg-[#f8f9f9] border-[#e6eff3] border-solid border-[0.063rem] box-border flex flex-col items-start justify-center !pt-0 !pb-0 !pl-2.5 !pr-2.5">
-        <div className="relative">{adSoyadnzGiriniz}</div>
-      </div>
+      </label>
+      <input
+        type="text"
+        placeholder={adSoyadnzGiriniz}
+        className="self-stretch h-10 rounded-[0.625rem] bg-[#f8f9f9] border-[#e6eff3] border-solid border-[0.063rem] box-border !pl-2.5 !pr-2.5"
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add anchor sections so navbar links scroll in-page
- make contact form interactive
- convert pricing inputs to active inputs
- open contact form in a modal for the Demo button
- update buttons and links in the header

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68493f8b3d9c832ca42a08ec63a7c2f5